### PR TITLE
fix dataframe intersection order issue

### DIFF
--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -130,7 +130,7 @@ def app():
 			for df in data_frames:
 				new_data_frames.append(df[(df.name == elem)])
 		list_diff.sort()
-		st.write(list_diff)
+		# st.write(list_diff)
 		return new_data_frames
 
 	def get_dataframe(file):
@@ -155,7 +155,7 @@ def app():
 		data_frames = [get_dataframe(file) for file in files]
 		new_data_frames = dataframe_intersection(data_frames=data_frames)
 		df = pd.concat(new_data_frames, sort=False)
-		st.write(df)
+		# st.write(df)
 		df.sort_values(['name'])
 		return df
 

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -145,51 +145,6 @@ def app():
 
 	def get_dataframes_from_files(files):
 		data_frames = [get_dataframe(file) for file in files]
-		# col_headers = reduce(lambda x, y : list(set(x["name"]) & set(y["name"])), data_frames)
-		# col_headers.remove("variant")
-		# st.write(col_headers)
-		smallest_size_df = min(data_frames, key=lambda x : x.index.stop)
-		# smallest_size_df_name_lst = list(smallest_size_df["name"])
-		# new_adf = []
-		# new_data_frames = []
-		# for adf in data_frames[1:]:
-		# 	for _, row in adf.iterrows():
-		# 		if row["name"] in smallest_size_df_name_lst:
-		# 			new_adf.append(row)
-		# 	new_data_frames.append(pd.DataFrame(new_adf))
-		# print(type(new_data_frames[0]))
-		# new_data_frames = []
-		# for d in data_frames:
-		# 	if smallest_size_df.equals(d):
-		# 		continue 
-		# 	else:
-		# 		diff = smallest_size_df.compare(d)
-		# 		st.write(diff["name"])
-		# lst = smallest_size_df["name"]
-		# def fun(e):
-		# 	return e in lst
-		new_data_frames = []
-		diff_data_frames = []
-		for d in data_frames:
-			diff = pd.concat([d,smallest_size_df]).drop_duplicates(subset = ['name'], keep=False)
-			diff_data_frames.append(diff)
-			# st.write(d[~d.name.isin(diff.name)])
-		# 	# cond = diff["name"].isin(d["name"])
-		# 	# d.drop(d[cond].index, inplace=True)
-		# 	# st.write(diff)
-		# 	# st.write(d)
-		# 	# st.write(d[~d.name.isin(diff.name)])
-		# 	# new_data_frames.append(d[~d.name.isin(diff.name)])
-		# 	# st.write(type(d.name))
-		# 	# d = d[(d.name != diff.name)]
-		# 	st.write(d.name.isin(diff.name))
-			# st.write("DIFF")
-			# st.write(diff)
-		for d in data_frames:
-			for diff in diff_data_frames:
-				new_d = d[~d.name.isin(diff.name)]
-			new_data_frames.append(new_d)
-			# st.write(new_d)
 
 		df = pd.concat(new_data_frames, sort=False)
 		df.sort_values(['name'])

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -123,7 +123,15 @@ def app():
 	selected_files = flatten(selected_benches.to_filepath())
 
 	def dataframe_intersection(data_frames):
-		pass
+		intersection_set_list = [set(df['name']) for df in data_frames]
+		list_diff = list(reduce(lambda x, y: x.intersection(y), intersection_set_list))
+		new_data_frames = []
+		for elem in list_diff:
+			for df in data_frames:
+				new_data_frames.append(df[(df.name == elem)])
+		list_diff.sort()
+		st.write(list_diff)
+		return new_data_frames
 
 	def get_dataframe(file):
 		# json to dataframe
@@ -145,10 +153,10 @@ def app():
 
 	def get_dataframes_from_files(files):
 		data_frames = [get_dataframe(file) for file in files]
-
+		new_data_frames = dataframe_intersection(data_frames=data_frames)
 		df = pd.concat(new_data_frames, sort=False)
+		st.write(df)
 		df.sort_values(['name'])
-		# st.write(df)
 		return df
 
 	def plot(df, y_axis):


### PR DESCRIPTION
This PR aims to resolve https://github.com/ocaml-bench/sandmark-nightly/issues/18

The issue was closed and reopened because the logic that I used to find the intersection did not take into consideration of the order and resulted in an index error when it was in a specific order.

But the PR aims to resolve it, the following image is the result of the changes (which previously resulted in the index error)
![sandmark-nightly-fix-issue-20](https://user-images.githubusercontent.com/13629677/142485897-548f2186-1f1c-4be6-a122-0573530f2dea.png)


