### PR TITLE
Use git clone from ocurrent-deployer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get -y install sudo git wget cron vim && \
     pip install --no-cache-dir streamlit nested_dict seaborn multipledispatch 
 RUN chmod 0644 /etc/cron.d/sandmark-nightly-client-crontab && \
     crontab /etc/cron.d/sandmark-nightly-client-crontab
-RUN git clone https://github.com/ocaml-bench/sandmark-nightly.git
 WORKDIR /sandmark-nightly
 COPY . .
 CMD streamlit run app/app.py


### PR DESCRIPTION
Not sure how this got re-introduced but you don't need the git clone here, it should be using the git clone from ocurrent-deployer.