### PR TITLE
add archive message for instrumented benchmarks

### DIFF
--- a/app/apps/instrumented_pausetimes_parallel.py
+++ b/app/apps/instrumented_pausetimes_parallel.py
@@ -18,6 +18,7 @@ from multipledispatch import dispatch
 
 def app():
     st.title("Instrumented Pausetimes (parallel)")
+    st.info("Archived Results - The current benchmarks are and do not reflect the latest nightly run")
 
 	# Problem : right now the structure is a nested dict of
 	#     `(hostname * (timestamp * (variants list)) dict ) dict`

--- a/app/apps/instrumented_pausetimes_sequential.py
+++ b/app/apps/instrumented_pausetimes_sequential.py
@@ -17,7 +17,7 @@ from multipledispatch import dispatch
 
 def app():
     st.title("Instrumented Pausetimes (sequential)")
-
+    st.info("Archived Results - The current benchmarks are and do not reflect the latest nightly run")
 	# Problem : right now the structure is a nested dict of
 	#     `(hostname * (timestamp * (variants list)) dict ) dict`
 	# and this nested structure although works but it is a bit difficult to work with


### PR DESCRIPTION
Since the instrumented pausetimes are not currently updated with the latest ocaml 5.0 there should be a way to make the user aware of this. The PR adds this info in the UI