### PR TITLE
Add sandmark info to sandmark nightly

### DIFF
--- a/app/apps/index.py
+++ b/app/apps/index.py
@@ -1,10 +1,41 @@
+from logging import StringTemplateStyle
 from sre_constants import GROUPREF_EXISTS
-import streamlit as st
+from unicodedata import name
 from git import Repo
-import pathlib
+from itertools import chain
+
+import streamlit as st
+import os, pathlib, re
+
+def get_commit_id(file):
+    file_ = open(file, "r")
+    for line in file_:
+        # commit keyword points to the latest commit of sandmark
+        if re.search('commit', line):
+            return line
+    
+    file_.close()
+
+def get_the_latest_commits(machine_list):
+    cwd = pathlib.Path.cwd()
+    sequential_machines_path = [cwd.joinpath('sequential', machine) for machine in machine_list]
+    logpath_list = list()
+    for seq_path in sequential_machines_path:
+        # max value of subdirectory (which is the timestamp) is the latest one present in nightly
+        subdirs = [path.name for path in sorted(seq_path.iterdir()) if path.is_dir()]
+        # get the path for the log which is added latest
+        log = [str(path) for path in sorted(seq_path.joinpath(max(subdirs)).rglob("*.log"))]
+        # the log file doesn't matter for the sandmark commit used so any file will do
+        first_log = log[0]
+        commit_dir = first_log.split('.')[-2]
+        logpath_list.append(first_log)
+    
+    commit_list = [(logpath.split('/')[-4], get_commit_id(logpath).split(' ')[1].strip()) for logpath in logpath_list]
+    return commit_list
 
 def app():
     st.title("Sandmark Nightly")
+    tuple_list_of_info = get_the_latest_commits(['turing', 'navajo'])
     st.markdown('''
         ### What is Sandmark Nightly?
         Sandmark Nightly is a pipeline which runs the [Sandmark](https://github.com/ocaml-bench/sandmark) benchmarks 
@@ -119,3 +150,7 @@ def app():
         ### Disclaimer 
         This app is not performance optimized and hence rendering time might be slow so please be patient with it, Thanks :D
     ''')
+    st.header("Sandmark info")
+    st.subheader("Latest commit")
+    for machine, commit in tuple_list_of_info:
+        st.text(machine + " | " + commit)


### PR DESCRIPTION
Following up on the fix for https://github.com/ocaml-bench/sandmark-nightly/issues/41 this PR adds a info section to the nightly UI landing page. This landing page shows the commit info used by sandmark to build the benchmarks.