### PR TITLE
Show benchmarks in a table to read the tooltip

### DIFF
--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -1,6 +1,7 @@
 from nested_dict import nested_dict
 import os
 from collections import OrderedDict
+import pandas as pd
 
 class BenchStruct:
     config = {}
@@ -54,3 +55,20 @@ class BenchStruct:
     def sort(self):
         self.structure = {k:OrderedDict(sorted(v.items(),reverse=True)) for k,v in self.structure.items()}
         self.structure = nested_dict(self.structure)
+    
+    def display(self):
+        data = list()
+        for host_timestamp_commit_tuple, variant_lst in self.structure.items_flat():
+            host = host_timestamp_commit_tuple[0]
+            timestamp = host_timestamp_commit_tuple[1]
+            commit_id = host_timestamp_commit_tuple[2]
+            if len(variant_lst) > 1:
+                temp_lst = [[host, timestamp, commit_id, variant] for variant in variant_lst]
+                for l in temp_lst:
+                    data.append(l)
+            else:
+                temp_lst = [host, timestamp, commit_id, variant_lst[0]]
+                data.append(temp_lst)
+
+        df_data = pd.DataFrame(data, columns=['hostname', 'timestamp', 'commit_id', 'variant'])
+        return df_data

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -87,8 +87,8 @@ def app():
 
 
     # Expander for showing bench files
-    with st.expander("Show metadata of selected benchmarks"):
-        st.write(selected_benches.structure)
+    st.subheader("Selected Benchmarks")
+    st.write(selected_benches.display())
 
     selected_files = flatten(selected_benches.to_filepath())
 

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -1,4 +1,3 @@
-from pandas.core.frame import DataFrame
 import streamlit as st
 from re import U, split, sub
 import numpy as np
@@ -127,8 +126,8 @@ def app():
 	selected_benches.sort()
 
 	# Expander for showing bench files
-	with st.expander("Show metadata of selected benchmarks"):
-		st.write(selected_benches.structure)
+	st.subheader("Benchmarks Selected")
+	st.write(selected_benches.display())
 
 	selected_files = flatten(selected_benches.to_filepath())
 


### PR DESCRIPTION
This PR adds a display function to `app/apps/benchstruct.py` to enable the UI to show the selected benchmarks and their various components - hostname, timestamp, commit id and variant name in a table. This makes reading of long names feasible.

This might be the closest way to know what we are selecting in absence of a tooltip function that displays the component name in streamlit.

The current way in which tooltip for streamlit works is more of an info for the component than for the data inside the component.
<img width="327" alt="Screenshot 2022-03-08 at 6 17 01 AM" src="https://user-images.githubusercontent.com/13629677/157152636-d4b8dd71-9293-4890-ae34-3f3cfa65c654.png">

so this PR tries to create a table out of selected benchmarks and the table by default has a tooltip display which makes things easier.
<img width="999" alt="Screenshot 2022-03-08 at 7 45 32 AM" src="https://user-images.githubusercontent.com/13629677/157152906-4c7bcdfc-449e-4ca4-8ea4-276e0fecb332.png">
