### PR TITLE
Hide instrumented runtime pages

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -14,8 +14,8 @@ app = MultiApp()
 app.add_app("Sandmark Nightly", index.app)
 app.add_app("Sequential Benchmarks", sequential_benchmarks.app)
 app.add_app("Parallel Benchmarks", parallel_benchmarks.app)
-app.add_app("Instrumented Pausetimes Sequential", instrumented_pausetimes_sequential.app)
-app.add_app("Instrumented Pausetimes Parallel", instrumented_pausetimes_parallel.app)
+#app.add_app("Instrumented Pausetimes Sequential", instrumented_pausetimes_sequential.app)
+#app.add_app("Instrumented Pausetimes Parallel", instrumented_pausetimes_parallel.app)
 
 # The main app
 app.run()

--- a/app/apps/index.py
+++ b/app/apps/index.py
@@ -13,7 +13,7 @@ def get_commit_id(file):
         # commit keyword points to the latest commit of sandmark
         if re.search('commit', line):
             return line
-    
+
     file_.close()
 
 def get_the_latest_commits(machine_list):
@@ -29,7 +29,7 @@ def get_the_latest_commits(machine_list):
         first_log = log[0]
         commit_dir = first_log.split('.')[-2]
         logpath_list.append(first_log)
-    
+
     commit_list = [(logpath.split('/')[-4], get_commit_id(logpath).split(' ')[1].strip()) for logpath in logpath_list]
     return commit_list
 
@@ -75,27 +75,6 @@ def app():
             - Metrics :
                 - Speedup
 
-        - Instrumented Pausetimes (sequential) :
-            The instrumented pausetimes are not updated currently
-            - Past :
-                - Variants :
-                    - OCaml 4.12.0+stock+instrumented
-                    - OCaml 4.12.0+domains+effects+instrumented
-                - Metrics :
-                    - Max Latency
-                    - 99.9th Percentile Latency
-                    - 99th Precentile Latency
-
-        - Instrumented Pausetimes (parallel) :
-            The instrumented pausetimes are not updated currently
-            - Past :
-                - Variants :
-                    - OCaml 4.12.0+domains+effects+instrumented
-                - Metrics :
-                    - Max Latency
-                    - 99.9th Percentile Latency
-                    - 99th Perecentile Latency
-                    - Mean Latency
         ### Machines used for generating results
         - Turing :
             - Basic Hardware and Software Info :
@@ -145,9 +124,6 @@ def app():
                     0:  10  22
                     1:  22  10
                 ```
-
-        ### Disclaimer
-        This app is not performance optimized and hence rendering time might be slow so please be patient with it, Thanks :D
     ''')
     st.header("Sandmark info")
     st.subheader("Latest commit")


### PR DESCRIPTION
Instrumented runtime is not used currently, and having those pages is a distraction. This PR hides it. 