### PR TITLE
Backport changes to normalise function from Sandmark notebook

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,12 +1,12 @@
 import streamlit as st
 from multiapp import MultiApp
-from apps import index, sequential_benchmarks, parallel_benchmarks # instrumented_pausetimes_sequential, instrumented_pausetimes_parallel ( import your app modules here )
+from apps import (
+    index,
+    sequential_benchmarks,
+    parallel_benchmarks,
+)  # instrumented_pausetimes_sequential, instrumented_pausetimes_parallel ( import your app modules here )
 
-st.set_page_config(
-    page_title="Sandmark Nightly",
-    page_icon="🐫",
-    layout="wide"
-)
+st.set_page_config(page_title="Sandmark Nightly", page_icon="🐫", layout="wide")
 
 app = MultiApp()
 
@@ -14,8 +14,8 @@ app = MultiApp()
 app.add_app("Home", index.app)
 app.add_app("Sequential Benchmarks", sequential_benchmarks.app)
 app.add_app("Parallel Benchmarks", parallel_benchmarks.app)
-#app.add_app("Instrumented Pausetimes Sequential", instrumented_pausetimes_sequential.app)
-#app.add_app("Instrumented Pausetimes Parallel", instrumented_pausetimes_parallel.app)
+# app.add_app("Instrumented Pausetimes Sequential", instrumented_pausetimes_sequential.app)
+# app.add_app("Instrumented Pausetimes Parallel", instrumented_pausetimes_parallel.app)
 
 # The main app
 app.run()

--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -3,6 +3,7 @@ import os
 from collections import OrderedDict
 import pandas as pd
 
+
 class BenchStruct:
     config = {}
 
@@ -11,27 +12,35 @@ class BenchStruct:
         self.config["bench_type"] = bench_type
         self.config["artifacts_dir"] = artifacts_dir
         self.config["bench_stem"] = bench_stem
-    
+
     def add(self, host, timestamp, commit, variant):
         self.structure[host][timestamp][commit].append(variant)
-    
+
     def add_files(self, files):
         for x in files:
             l = x.split(str("/" + self.config["bench_type"] + "/"))[1]
             d = l.split("/")
-            self.add(
-                d[0],
-                d[1],
-                d[2],
-                d[3]
-            )
-    
+            self.add(d[0], d[1], d[2], d[3])
+
     def to_filepath(self):
         lst = []
         for host, timestamps in self.structure.items():
             for timestamp, commits in timestamps.items():
                 for commit, bench_files in commits.items():
-                    t = [self.config["artifacts_dir"] + "/" + self.config["bench_type"] + "/" + str(host) + "/" + str(timestamp) + "/" + str(commit) + "/" + str(bench_file) for bench_file in bench_files]
+                    t = [
+                        self.config["artifacts_dir"]
+                        + "/"
+                        + self.config["bench_type"]
+                        + "/"
+                        + str(host)
+                        + "/"
+                        + str(timestamp)
+                        + "/"
+                        + str(commit)
+                        + "/"
+                        + str(bench_file)
+                        for bench_file in bench_files
+                    ]
                     lst.append(t)
         return lst
 
@@ -39,23 +48,27 @@ class BenchStruct:
         bench_files = []
 
         # Loads file metadata
-        for root, dirs, files in os.walk(self.config["artifacts_dir"] + "/" + self.config["bench_type"]):
+        for root, dirs, files in os.walk(
+            self.config["artifacts_dir"] + "/" + self.config["bench_type"]
+        ):
             for file in files:
                 if file.endswith(self.config["bench_stem"]):
                     f = root.split("/" + self.config["bench_type"])
-                    bench_files.append((os.path.join(root,file)))
-        
+                    bench_files.append((os.path.join(root, file)))
+
         # print(bench_files)
         return bench_files
 
-
     def __repr__(self):
-        return f'{self.structure}'
-    
+        return f"{self.structure}"
+
     def sort(self):
-        self.structure = {k:OrderedDict(sorted(v.items(),reverse=True)) for k,v in self.structure.items()}
+        self.structure = {
+            k: OrderedDict(sorted(v.items(), reverse=True))
+            for k, v in self.structure.items()
+        }
         self.structure = nested_dict(self.structure)
-    
+
     def display(self):
         data = list()
         for host_timestamp_commit_tuple, variant_lst in self.structure.items_flat():
@@ -63,12 +76,16 @@ class BenchStruct:
             timestamp = host_timestamp_commit_tuple[1]
             commit_id = host_timestamp_commit_tuple[2]
             if len(variant_lst) > 1:
-                temp_lst = [[host, timestamp, commit_id, variant] for variant in variant_lst]
+                temp_lst = [
+                    [host, timestamp, commit_id, variant] for variant in variant_lst
+                ]
                 for l in temp_lst:
                     data.append(l)
             else:
                 temp_lst = [host, timestamp, commit_id, variant_lst[0]]
                 data.append(temp_lst)
 
-        df_data = pd.DataFrame(data, columns=['hostname', 'timestamp', 'commit_id', 'variant'])
+        df_data = pd.DataFrame(
+            data, columns=["hostname", "timestamp", "commit_id", "variant"]
+        )
         return df_data

--- a/app/apps/index.py
+++ b/app/apps/index.py
@@ -7,36 +7,47 @@ from itertools import chain
 import streamlit as st
 import os, pathlib, re
 
+
 def get_commit_id(file):
     file_ = open(file, "r")
     for line in file_:
         # commit keyword points to the latest commit of sandmark
-        if re.search('commit', line):
+        if re.search("commit", line):
             return line
 
     file_.close()
 
+
 def get_the_latest_commits(machine_list):
     cwd = pathlib.Path.cwd()
-    sequential_machines_path = [cwd.joinpath('sequential', machine) for machine in machine_list]
+    sequential_machines_path = [
+        cwd.joinpath("sequential", machine) for machine in machine_list
+    ]
     logpath_list = list()
     for seq_path in sequential_machines_path:
         # max value of subdirectory (which is the timestamp) is the latest one present in nightly
         subdirs = [path.name for path in sorted(seq_path.iterdir()) if path.is_dir()]
         # get the path for the log which is added latest
-        log = [str(path) for path in sorted(seq_path.joinpath(max(subdirs)).rglob("*.log"))]
+        log = [
+            str(path) for path in sorted(seq_path.joinpath(max(subdirs)).rglob("*.log"))
+        ]
         # the log file doesn't matter for the sandmark commit used so any file will do
         first_log = log[0]
-        commit_dir = first_log.split('.')[-2]
+        commit_dir = first_log.split(".")[-2]
         logpath_list.append(first_log)
 
-    commit_list = [(logpath.split('/')[-4], get_commit_id(logpath).split(' ')[1].strip()) for logpath in logpath_list]
+    commit_list = [
+        (logpath.split("/")[-4], get_commit_id(logpath).split(" ")[1].strip())
+        for logpath in logpath_list
+    ]
     return commit_list
+
 
 def app():
     st.title("Sandmark Nightly")
-    tuple_list_of_info = get_the_latest_commits(['turing', 'navajo'])
-    st.markdown('''
+    tuple_list_of_info = get_the_latest_commits(["turing", "navajo"])
+    st.markdown(
+        """
         ### What is Sandmark Nightly?
         Sandmark Nightly is a pipeline which runs the [Sandmark](https://github.com/ocaml-bench/sandmark) benchmarks
         and uses these results to generate graphs for important metrics.
@@ -122,7 +133,8 @@ def app():
                     0:  10  22
                     1:  22  10
                 ```
-    ''')
+    """
+    )
     st.header("Sandmark info")
     st.subheader("Latest commit")
     for machine, commit in tuple_list_of_info:

--- a/app/apps/instrumented_pausetimes_parallel.py
+++ b/app/apps/instrumented_pausetimes_parallel.py
@@ -16,76 +16,82 @@ import seaborn as sns
 from apps import benchstruct
 from multipledispatch import dispatch
 
+
 def app():
     st.title("Instrumented Pausetimes (parallel)")
-    st.info("Archived Results - The current benchmarks are and do not reflect the latest nightly run")
+    st.info(
+        "Archived Results - The current benchmarks are and do not reflect the latest nightly run"
+    )
 
-	# Problem : right now the structure is a nested dict of
-	#     `(hostname * (timestamp * (variants list)) dict ) dict`
-	# and this nested structure although works but it is a bit difficult to work with
-	# so we need to create a class object which is a record type and add
-	# functions to
+    # Problem : right now the structure is a nested dict of
+    #     `(hostname * (timestamp * (variants list)) dict ) dict`
+    # and this nested structure although works but it is a bit difficult to work with
+    # so we need to create a class object which is a record type and add
+    # functions to
 
-	# <host 1>
-	# |--- <timestamp 1>
-	#         |--- <commit 1>
-	#                 |--- <variant 1>
-	#                 |--- <variant 2>
-	#                 ....
-	#                 ....
-	#                 ....
-	#                 |--- <variant n>
-	#         |--- <commit 2>
-	#                 ....
-	#                 ....
-	#                 ....
-	#         ....
-	#         ....
-	#         ....
-	#         |--- <commit n>
-	#                 ....
-	#                 ....
-	#                 ....
-	# ....
-	# ....
-	# ....
-	# ....
-	# |--- <timestamp n>
-	#         ....
-	#         ....
-	# <host 2>
-	# ....
-	# ....
-	# ....
-	# <host n>
+    # <host 1>
+    # |--- <timestamp 1>
+    #         |--- <commit 1>
+    #                 |--- <variant 1>
+    #                 |--- <variant 2>
+    #                 ....
+    #                 ....
+    #                 ....
+    #                 |--- <variant n>
+    #         |--- <commit 2>
+    #                 ....
+    #                 ....
+    #                 ....
+    #         ....
+    #         ....
+    #         ....
+    #         |--- <commit n>
+    #                 ....
+    #                 ....
+    #                 ....
+    # ....
+    # ....
+    # ....
+    # ....
+    # |--- <timestamp n>
+    #         ....
+    #         ....
+    # <host 2>
+    # ....
+    # ....
+    # ....
+    # <host n>
 
-	# This idea is only for sandmark nightly
+    # This idea is only for sandmark nightly
 
     class BenchStruct(benchstruct.BenchStruct):
-
         def get_bench_files(self):
             bench_files = []
 
             # Loads file metadata
-            for root, dirs, files in os.walk(self.config["artifacts_dir"] + "/" + self.config["bench_type"]):
+            for root, dirs, files in os.walk(
+                self.config["artifacts_dir"] + "/" + self.config["bench_type"]
+            ):
                 for file in files:
                     if file.endswith(self.config["bench_stem"]):
                         f = root.split("/" + self.config["bench_type"])
-                        bench_files.append((os.path.join(root,file)))
+                        bench_files.append((os.path.join(root, file)))
 
             return bench_files
 
-    current = os.getcwd().split('/')
+    current = os.getcwd().split("/")
     current.pop()
-    artifacts_dir = '/'.join(current) + '/sandmark-nightly' + '/pausetimes'
+    artifacts_dir = "/".join(current) + "/sandmark-nightly" + "/pausetimes"
     # print(artifacts_dir)
 
-    benches = BenchStruct("parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench")
+    benches = BenchStruct(
+        "parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench"
+    )
     benches.add_files(benches.get_bench_files())
     benches.sort()
 
     st.header("Select variants")
-    n = int(st.text_input('Number of variants','2', key=benches.config["bench_type"]))
+    n = int(st.text_input("Number of variants", "2", key=benches.config["bench_type"]))
 
     containers = [st.columns(3) for i in range(n)]
 
@@ -95,7 +101,7 @@ def app():
 
     # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
     def unzip(lst):
-        return (list(zip(*lst)))
+        return list(zip(*lst))
 
     def unzip_dict(d):
         a = unzip(list(d))
@@ -105,48 +111,83 @@ def app():
 
     @dispatch(str)
     def fmt_variant(file):
-        variant   = file.split('/')[-1].split('_1')[0]
-        commit_id = file.split('/')[-2][:7]
-        date      = file.split('/')[-3].split('_')[0]
+        variant = file.split("/")[-1].split("_1")[0]
+        commit_id = file.split("/")[-2][:7]
+        date = file.split("/")[-3].split("_")[0]
         return str(variant + "_" + date + "_" + commit_id)
 
-    @dispatch(str,str)
+    @dispatch(str, str)
     def fmt_variant(commit, variant):
         # st.write(variant.split('_'))
-        return (variant.split('_')[0] + '+' + str(commit) + '_' + variant.split('_')[1] + '_' + variant.split('_')[2])
+        return (
+            variant.split("_")[0]
+            + "+"
+            + str(commit)
+            + "_"
+            + variant.split("_")[1]
+            + "_"
+            + variant.split("_")[2]
+        )
 
     def unfmt_variant(variant):
-        commit = variant.split('_')[0].split('+')[-1]
-        variant_root = variant.split('_')[1] + '_' + variant.split('_')[2]
+        commit = variant.split("_")[0].split("+")[-1]
+        variant_root = variant.split("_")[1] + "_" + variant.split("_")[2]
         # st.write(variant_root)
-        variant_stem = variant.split('_')[0].split('+')
+        variant_stem = variant.split("_")[0].split("+")
         variant_stem.pop()
-        variant_stem = reduce(lambda a, b: b if a == "" else a + "+" + b, variant_stem, "")
-        new_variant = variant_stem + '_' + variant_root
+        variant_stem = reduce(
+            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
+        )
+        new_variant = variant_stem + "_" + variant_root
         # st.write(new_variant)
-        return (commit , new_variant)
-
+        return (commit, new_variant)
 
     def get_selected_values(n):
         lst = []
         for i in range(n):
             # create the selectbox in columns
-            host_val = containers[i][0].selectbox('hostname', benches.structure.keys(), key = str(i) + '0_' + benches.config["bench_type"])
-            timestamp_val = containers[i][1].selectbox('timestamp', benches.structure[host_val].keys(), key = str(i) + '1_' + benches.config["bench_type"])
+            host_val = containers[i][0].selectbox(
+                "hostname",
+                benches.structure.keys(),
+                key=str(i) + "0_" + benches.config["bench_type"],
+            )
+            timestamp_val = containers[i][1].selectbox(
+                "timestamp",
+                benches.structure[host_val].keys(),
+                key=str(i) + "1_" + benches.config["bench_type"],
+            )
             # st.write((benches.structure[host_val][timestamp_val]).items())
             if (benches.structure[host_val][timestamp_val]).items():
-                commits, variants = unzip_dict((benches.structure[host_val][timestamp_val]).items())
+                commits, variants = unzip_dict(
+                    (benches.structure[host_val][timestamp_val]).items()
+                )
                 # st.write(variants)
-                fmtted_variants = [fmt_variant(c, v) for c,v in zip(commits, variants)]
+                fmtted_variants = [fmt_variant(c, v) for c, v in zip(commits, variants)]
                 # st.write(fmtted_variants)
-                variant_val = containers[i][2].selectbox('variant', fmtted_variants, key = str(i) + '2_' + benches.config["bench_type"])
+                variant_val = containers[i][2].selectbox(
+                    "variant",
+                    fmtted_variants,
+                    key=str(i) + "2_" + benches.config["bench_type"],
+                )
                 selected_commit, selected_variant = unfmt_variant(variant_val)
-                lst.append({"host" : host_val, "timestamp" : timestamp_val, "commit" : selected_commit, "variant" : selected_variant})
+                lst.append(
+                    {
+                        "host": host_val,
+                        "timestamp": timestamp_val,
+                        "commit": selected_commit,
+                        "variant": selected_variant,
+                    }
+                )
 
         return lst
 
-    selected_benches = BenchStruct( "parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench")
-    _ = [selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"]) for f in get_selected_values(n)]
+    selected_benches = BenchStruct(
+        "parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench"
+    )
+    _ = [
+        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
+        for f in get_selected_values(n)
+    ]
     selected_benches.sort()
 
     # Expander for showing bench files
@@ -167,78 +208,95 @@ def app():
 
         return df
 
-
     def get_dataframes_from_files(files):
         data_frames = [get_dataframe(file) for file in files]
-        df = pd.concat (data_frames, sort=False)
+        df = pd.concat(data_frames, sort=False)
 
-        mdf = df.loc[df['name'].str.contains('.*multicore.*',regex=True),:]
-        mdf['num_domains'] = mdf['name'].str.split('.',expand=True)[1].str.split('_',expand=True)[0]
-        mdf['num_domains'] = pd.to_numeric(mdf['num_domains'])
-        mdf['name'] = mdf['name'].replace('\..*?_','.',regex=True)
+        mdf = df.loc[df["name"].str.contains(".*multicore.*", regex=True), :]
+        mdf["num_domains"] = (
+            mdf["name"].str.split(".", expand=True)[1].str.split("_", expand=True)[0]
+        )
+        mdf["num_domains"] = pd.to_numeric(mdf["num_domains"])
+        mdf["name"] = mdf["name"].replace("\..*?_", ".", regex=True)
 
-        mdf = mdf.drop_duplicates(subset=["name","variant", "max_latency", "num_domains"])
-        mdf = mdf.sort_values(['name'])
+        mdf = mdf.drop_duplicates(
+            subset=["name", "variant", "max_latency", "num_domains"]
+        )
+        mdf = mdf.sort_values(["name"])
         return mdf
 
     mdf = get_dataframes_from_files(selected_files)
 
     def renameForLatency(n):
-        n = n.replace("name = ","")
-        return re.sub("_multicore\..*","",n)
+        n = n.replace("name = ", "")
+        return re.sub("_multicore\..*", "", n)
 
-    def plotLatencyAt(df,at):
-        fdf = df.filter(["name","variant",at + "_latency","num_domains"])
-        fdf.sort_values(by="name",inplace=True)
+    def plotLatencyAt(df, at):
+        fdf = df.filter(["name", "variant", at + "_latency", "num_domains"])
+        fdf.sort_values(by="name", inplace=True)
         fdf[at + "_latency"] = fdf[at + "_latency"] / 1000.0
-        with sns.plotting_context(rc={"font.size":14,"axes.titlesize":14,"axes.labelsize":14,
-                                    "legend.fontsize":14}):
-            g = sns.relplot(x='num_domains', y = at + '_latency', hue='variant', col='name',
-                data=fdf, kind='line', style='variant', markers=True, col_wrap = 4,
-                height = 3)
+        with sns.plotting_context(
+            rc={
+                "font.size": 14,
+                "axes.titlesize": 14,
+                "axes.labelsize": 14,
+                "legend.fontsize": 14,
+            }
+        ):
+            g = sns.relplot(
+                x="num_domains",
+                y=at + "_latency",
+                hue="variant",
+                col="name",
+                data=fdf,
+                kind="line",
+                style="variant",
+                markers=True,
+                col_wrap=4,
+                height=3,
+            )
             for ax in g.axes:
                 ax.set_title(renameForLatency(ax.title.get_text()))
                 ax.set_ylabel(at + " latency (μs)")
                 ax.set_xlabel("# Domains")
-                ax.set_yscale('log')
+                ax.set_yscale("log")
             return g
 
     st.header("Max Latency")
     with st.expander("Expand"):
-        #st.write(mdf)
+        # st.write(mdf)
 
-        max_latency_g = plotLatencyAt(mdf,"max")
+        max_latency_g = plotLatencyAt(mdf, "max")
         st.pyplot(max_latency_g)
 
-
-    def getLatencyAt(df,percentile,idx):
-        groups = df.groupby('variant')
+    def getLatencyAt(df, percentile, idx):
+        groups = df.groupby("variant")
         ndfs = []
         for group in groups:
-            (v,df) = group
+            (v, df) = group
             count = 0
             for i, row in df.iterrows():
                 count += 1
-                df.at[i,percentile+"_latency"] = list(df.at[i,"distr_latency"])[idx]
+                df.at[i, percentile + "_latency"] = list(df.at[i, "distr_latency"])[idx]
             print(count)
             ndfs.append(df)
         return pd.concat(ndfs)
 
-    mdf2 = getLatencyAt(mdf,"99.9",-1)
+    mdf2 = getLatencyAt(mdf, "99.9", -1)
     st.header("99.9th Percentile Latency")
     with st.expander("Expand"):
-        #st.write(mdf2.filter(["name","variant","99.9_latency"]))
+        # st.write(mdf2.filter(["name","variant","99.9_latency"]))
 
-        g_99_9 = plotLatencyAt(mdf2,"99.9")
+        g_99_9 = plotLatencyAt(mdf2, "99.9")
         st.pyplot(g_99_9)
 
-    mdf3 = getLatencyAt(mdf,"99",-2)
+    mdf3 = getLatencyAt(mdf, "99", -2)
     st.header("99th Percentile Latency")
     with st.expander("Expand"):
-        #st.write(mdf3.filter(["name","variant","99_latency"]))
+        # st.write(mdf3.filter(["name","variant","99_latency"]))
 
-        g_99 = plotLatencyAt(mdf3,"99")
+        g_99 = plotLatencyAt(mdf3, "99")
         st.pyplot(g_99)
 
     st.header("Mean Latency")
-    st.pyplot(plotLatencyAt(mdf,"mean"))
+    st.pyplot(plotLatencyAt(mdf, "mean"))

--- a/app/apps/instrumented_pausetimes_sequential.py
+++ b/app/apps/instrumented_pausetimes_sequential.py
@@ -15,73 +15,83 @@ import seaborn as sns
 from apps import benchstruct
 from multipledispatch import dispatch
 
+
 def app():
     st.title("Instrumented Pausetimes (sequential)")
-    st.info("Archived Results - The current benchmarks are and do not reflect the latest nightly run")
-	# Problem : right now the structure is a nested dict of
-	#     `(hostname * (timestamp * (variants list)) dict ) dict`
-	# and this nested structure although works but it is a bit difficult to work with
-	# so we need to create a class object which is a record type and add
-	# functions to
+    st.info(
+        "Archived Results - The current benchmarks are and do not reflect the latest nightly run"
+    )
+    # Problem : right now the structure is a nested dict of
+    #     `(hostname * (timestamp * (variants list)) dict ) dict`
+    # and this nested structure although works but it is a bit difficult to work with
+    # so we need to create a class object which is a record type and add
+    # functions to
 
-	# <host 1>
-	# |--- <timestamp 1>
-	#         |--- <commit 1>
-	#                 |--- <variant 1>
-	#                 |--- <variant 2>
-	#                 ....
-	#                 ....
-	#                 ....
-	#                 |--- <variant n>
-	#         |--- <commit 2>
-	#                 ....
-	#                 ....
-	#                 ....
-	#         ....
-	#         ....
-	#         ....
-	#         |--- <commit n>
-	#                 ....
-	#                 ....
-	#                 ....
-	# ....
-	# ....
-	# ....
-	# ....
-	# |--- <timestamp n>
-	#         ....
-	#         ....
-	# <host 2>
-	# ....
-	# ....
-	# ....
-	# <host n>
+    # <host 1>
+    # |--- <timestamp 1>
+    #         |--- <commit 1>
+    #                 |--- <variant 1>
+    #                 |--- <variant 2>
+    #                 ....
+    #                 ....
+    #                 ....
+    #                 |--- <variant n>
+    #         |--- <commit 2>
+    #                 ....
+    #                 ....
+    #                 ....
+    #         ....
+    #         ....
+    #         ....
+    #         |--- <commit n>
+    #                 ....
+    #                 ....
+    #                 ....
+    # ....
+    # ....
+    # ....
+    # ....
+    # |--- <timestamp n>
+    #         ....
+    #         ....
+    # <host 2>
+    # ....
+    # ....
+    # ....
+    # <host n>
 
-	# This idea is only for sandmark nightly
+    # This idea is only for sandmark nightly
 
     class BenchStruct(benchstruct.BenchStruct):
-        
         def get_bench_files(self):
             bench_files = []
 
             # Loads file metadata
-            for root, dirs, files in os.walk(self.config["artifacts_dir"] + "/" + self.config["bench_type"]):
+            for root, dirs, files in os.walk(
+                self.config["artifacts_dir"] + "/" + self.config["bench_type"]
+            ):
                 for file in files:
-                    if file.endswith(self.config["bench_stem"][0]) or file.endswith(self.config["bench_stem"][1]):
+                    if file.endswith(self.config["bench_stem"][0]) or file.endswith(
+                        self.config["bench_stem"][1]
+                    ):
                         f = root.split("/" + self.config["bench_type"])
-                        bench_files.append((os.path.join(root,file)))
-            
+                        bench_files.append((os.path.join(root, file)))
+
             return bench_files
 
-    current = os.getcwd().split('/')
+    current = os.getcwd().split("/")
     current.pop()
-    artifacts_dir = '/'.join(current) + '/sandmark-nightly' + '/pausetimes'
-    benches = BenchStruct( "sequential", artifacts_dir, ["_1.pausetimes_trunk.summary.bench","_1.pausetimes_multicore.summary.bench"])
+    artifacts_dir = "/".join(current) + "/sandmark-nightly" + "/pausetimes"
+    benches = BenchStruct(
+        "sequential",
+        artifacts_dir,
+        ["_1.pausetimes_trunk.summary.bench", "_1.pausetimes_multicore.summary.bench"],
+    )
     benches.add_files(benches.get_bench_files())
     benches.sort()
 
     st.header("Select variants")
-    n = int(st.text_input('Number of variants','2', key=benches.config["bench_type"]))
+    n = int(st.text_input("Number of variants", "2", key=benches.config["bench_type"]))
 
     containers = [st.columns(3) for i in range(n)]
 
@@ -91,58 +101,95 @@ def app():
 
     # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
     def unzip(lst):
-        return (list(zip(*lst)))
+        return list(zip(*lst))
 
     def unzip_dict(d):
         a = unzip(list(d))
         # st.write(a)
         (x, y) = a[0], flatten(a[1])
         return (x, y)
-    
+
     @dispatch(str)
     def fmt_variant(file):
-        variant   = file.split('/')[-1].split('_1')[0]
-        commit_id = file.split('/')[-2][:7]
-        date      = file.split('/')[-3].split('_')[0]
+        variant = file.split("/")[-1].split("_1")[0]
+        commit_id = file.split("/")[-2][:7]
+        date = file.split("/")[-3].split("_")[0]
         return str(variant + "_" + date + "_" + commit_id)
 
-    @dispatch(str,str)
+    @dispatch(str, str)
     def fmt_variant(commit, variant):
         # st.write(variant.split('_'))
-        return (variant.split('_')[0] + '+' + str(commit) + '_' + variant.split('_')[1] + '_' + variant.split('_')[2])
+        return (
+            variant.split("_")[0]
+            + "+"
+            + str(commit)
+            + "_"
+            + variant.split("_")[1]
+            + "_"
+            + variant.split("_")[2]
+        )
 
     def unfmt_variant(variant):
-        commit = variant.split('_')[0].split('+')[-1]
-        variant_root = variant.split('_')[1] + '_' + variant.split('_')[2]
+        commit = variant.split("_")[0].split("+")[-1]
+        variant_root = variant.split("_")[1] + "_" + variant.split("_")[2]
         # st.write(variant_root)
-        variant_stem = variant.split('_')[0].split('+')
+        variant_stem = variant.split("_")[0].split("+")
         variant_stem.pop()
-        variant_stem = reduce(lambda a, b: b if a == "" else a + "+" + b, variant_stem, "")
-        new_variant = variant_stem + '_' + variant_root
+        variant_stem = reduce(
+            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
+        )
+        new_variant = variant_stem + "_" + variant_root
         # st.write(new_variant)
-        return (commit , new_variant)
-    
+        return (commit, new_variant)
 
     def get_selected_values(n):
         lst = []
         for i in range(n):
             # create the selectbox in columns
-            host_val = containers[i][0].selectbox('hostname', benches.structure.keys(), key = str(i) + '0_' + benches.config["bench_type"])
-            timestamp_val = containers[i][1].selectbox('timestamp', benches.structure[host_val].keys(), key = str(i) + '1_' + benches.config["bench_type"])
+            host_val = containers[i][0].selectbox(
+                "hostname",
+                benches.structure.keys(),
+                key=str(i) + "0_" + benches.config["bench_type"],
+            )
+            timestamp_val = containers[i][1].selectbox(
+                "timestamp",
+                benches.structure[host_val].keys(),
+                key=str(i) + "1_" + benches.config["bench_type"],
+            )
             # st.write((benches.structure[host_val][timestamp_val]).items())
             if (benches.structure[host_val][timestamp_val]).items():
-                commits, variants = unzip_dict((benches.structure[host_val][timestamp_val]).items())
+                commits, variants = unzip_dict(
+                    (benches.structure[host_val][timestamp_val]).items()
+                )
                 # st.write(variants)
-                fmtted_variants = [fmt_variant(c, v) for c,v in zip(commits, variants)]
+                fmtted_variants = [fmt_variant(c, v) for c, v in zip(commits, variants)]
                 # st.write(fmtted_variants)
-                variant_val = containers[i][2].selectbox('variant', fmtted_variants, key = str(i) + '2_' + benches.config["bench_type"])
+                variant_val = containers[i][2].selectbox(
+                    "variant",
+                    fmtted_variants,
+                    key=str(i) + "2_" + benches.config["bench_type"],
+                )
                 selected_commit, selected_variant = unfmt_variant(variant_val)
-                lst.append({"host" : host_val, "timestamp" : timestamp_val, "commit" : selected_commit, "variant" : selected_variant})
-    
+                lst.append(
+                    {
+                        "host": host_val,
+                        "timestamp": timestamp_val,
+                        "commit": selected_commit,
+                        "variant": selected_variant,
+                    }
+                )
+
         return lst
 
-    selected_benches = BenchStruct( "sequential", artifacts_dir, ["_1.pausetimes_trunk.summary.bench","_1.pausetimes_multicore.summary.bench"])
-    _ = [selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"]) for f in get_selected_values(n)]
+    selected_benches = BenchStruct(
+        "sequential",
+        artifacts_dir,
+        ["_1.pausetimes_trunk.summary.bench", "_1.pausetimes_multicore.summary.bench"],
+    )
+    _ = [
+        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
+        for f in get_selected_values(n)
+    ]
     selected_benches.sort()
 
     # Expander for showing bench files
@@ -160,68 +207,78 @@ def app():
                 data.append(json.loads(l))
             df = pdjson.json_normalize(data)
         df["variant"] = fmt_variant(file)
-        
-        return df
 
+        return df
 
     def get_dataframes_from_files(files):
         data_frames = [get_dataframe(file) for file in files]
-        df = pd.concat (data_frames, sort=False)
-        df = df.sort_values(['name'])
+        df = pd.concat(data_frames, sort=False)
+        df = df.sort_values(["name"])
         ## Drop some benchmarks
-        df = df[(df.name != 'alt-ergo.fill.why') & #multicore version does not exist
-                (df.name != 'alt-ergo.yyll.why') & #multicore version does not exist
-                (df.name != 'frama-c.slevel') &    #multicore version does not exist
-                (df.name != 'js_of_ocaml.frama-c_byte') &    #multicore version does not exist
-                (df.name != 'cpdf.merge') &
-                (df.name != 'coq.BasicSyntax.v') & (df.name != 'coq.AbstractInterpretation.v') # coq benchmarks not building
-                ]         #Not a macro benchmark. Will be removed from subsequent runs.
+        df = df[
+            (df.name != "alt-ergo.fill.why")
+            & (df.name != "alt-ergo.yyll.why")  # multicore version does not exist
+            & (df.name != "frama-c.slevel")  # multicore version does not exist
+            & (  # multicore version does not exist
+                df.name != "js_of_ocaml.frama-c_byte"
+            )
+            & (df.name != "cpdf.merge")  # multicore version does not exist
+            & (df.name != "coq.BasicSyntax.v")
+            & (df.name != "coq.AbstractInterpretation.v")  # coq benchmarks not building
+        ]  # Not a macro benchmark. Will be removed from subsequent runs.
         return df
-    
+
     df = get_dataframes_from_files(selected_files)
-    df = df.drop_duplicates(subset=['name', 'variant', 'max_latency'])
-    
-    def plotLatencyAt(df,at,aspect):
-        fdf = df.filter(["name","variant",at + "_latency"])
-        fdf.sort_values(by=[at + '_latency'],inplace=True)
+    df = df.drop_duplicates(subset=["name", "variant", "max_latency"])
+
+    def plotLatencyAt(df, at, aspect):
+        fdf = df.filter(["name", "variant", at + "_latency"])
+        fdf.sort_values(by=[at + "_latency"], inplace=True)
         fdf[at + "_latency"] = fdf[at + "_latency"] / 1000.0
-        g = sns.catplot (x='name', y=at+'_latency', hue='variant', data = fdf, kind ='bar', aspect=aspect)
+        g = sns.catplot(
+            x="name",
+            y=at + "_latency",
+            hue="variant",
+            data=fdf,
+            kind="bar",
+            aspect=aspect,
+        )
         g.set_xticklabels(rotation=90)
         g.ax.set_ylabel(at + " latency (microseconds)")
         g.ax.set_xlabel("Benchmarks")
-        g.ax.set_yscale('log')
+        g.ax.set_yscale("log")
         return g
 
     st.header("Max Latency")
     with st.expander("Expand"):
-        st.write(df.filter(["name","variant","max_latency"]))
+        st.write(df.filter(["name", "variant", "max_latency"]))
 
-        max_latency_g = plotLatencyAt(df,"max",4)
+        max_latency_g = plotLatencyAt(df, "max", 4)
         st.pyplot(max_latency_g)
-    
-    def getLatencyAt(df,percentile,idx):
-        groups = df.groupby('variant')
+
+    def getLatencyAt(df, percentile, idx):
+        groups = df.groupby("variant")
         ndfs = []
         for group in groups:
-            (v,df) = group
+            (v, df) = group
             count = 0
             for i, row in df.iterrows():
-                df.at[i,percentile+"_latency"] = list(df.at[i,"distr_latency"])[idx]
+                df.at[i, percentile + "_latency"] = list(df.at[i, "distr_latency"])[idx]
             ndfs.append(df)
         return pd.concat(ndfs)
 
-    df2 = getLatencyAt(df,"99.9",-1)
+    df2 = getLatencyAt(df, "99.9", -1)
     st.header("99.9th Percentile Latency")
     with st.expander("Expand"):
-        st.write(df2.filter(["name","variant","99.9_latency"]))
+        st.write(df2.filter(["name", "variant", "99.9_latency"]))
 
-        g_99_9 = plotLatencyAt(df2,"99.9",4)
+        g_99_9 = plotLatencyAt(df2, "99.9", 4)
         st.pyplot(g_99_9)
-    
-    df3 = getLatencyAt(df,"99",-2)
+
+    df3 = getLatencyAt(df, "99", -2)
     st.header("99th Percentile Latency")
     with st.expander("Expand"):
-        st.write(df3.filter(["name","variant","99_latency"]))
+        st.write(df3.filter(["name", "variant", "99_latency"]))
 
-        g_99 = plotLatencyAt(df3,"99",4)
+        g_99 = plotLatencyAt(df3, "99", 4)
         st.pyplot(g_99)

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -15,18 +15,21 @@ import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
 
+
 def app():
     st.title("Parallel Benchmarks")
 
-    current = os.getcwd().split('/')
+    current = os.getcwd().split("/")
     current.pop()
-    artifacts_dir = '/'.join(current) + '/sandmark-nightly'
-    benches = benchstruct.BenchStruct("parallel", artifacts_dir, "_1.orunchrt.summary.bench")
+    artifacts_dir = "/".join(current) + "/sandmark-nightly"
+    benches = benchstruct.BenchStruct(
+        "parallel", artifacts_dir, "_1.orunchrt.summary.bench"
+    )
     benches.add_files(benches.get_bench_files())
     benches.sort()
 
     st.header("Select variants")
-    n = int(st.text_input('Number of variants','1', key=benches.config["bench_type"]))
+    n = int(st.text_input("Number of variants", "1", key=benches.config["bench_type"]))
 
     containers = [st.columns(3) for i in range(n)]
 
@@ -36,7 +39,7 @@ def app():
 
     # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
     def unzip(lst):
-        return (list(zip(*lst)))
+        return list(zip(*lst))
 
     def unzip_dict(d):
         a = unzip(list(d))
@@ -48,43 +51,69 @@ def app():
         # st.write(commit)
         # st.write(variant)
         def fmt(commit, variant):
-            variant_name = variant.split('_')[0]
+            variant_name = variant.split("_")[0]
             commit_id = str(commit)
-            variant_tail = variant.split('_')[1]
-            return (variant.split('_')[0] + '+' + str(commit) + '_' + variant.split('_')[1])
+            variant_tail = variant.split("_")[1]
+            return (
+                variant.split("_")[0] + "+" + str(commit) + "_" + variant.split("_")[1]
+            )
+
         fmt_variant_lst = [fmt(commit, v) for v in variant_lst]
         return fmt_variant_lst
 
     def unfmt_variant(variant):
-        commit = variant.split('_')[0].split('+')[-1]
-        variant_root = variant.split('_')[1]
-        variant_stem = variant.split('_')[0].split('+')
+        commit = variant.split("_")[0].split("+")[-1]
+        variant_root = variant.split("_")[1]
+        variant_stem = variant.split("_")[0].split("+")
         variant_stem.pop()
-        variant_stem = reduce(lambda a, b: b if a == "" else a + "+" + b, variant_stem, "")
-        new_variant = variant_stem + '_' + variant_root
+        variant_stem = reduce(
+            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
+        )
+        new_variant = variant_stem + "_" + variant_root
         # st.write(new_variant)
-        return (commit , new_variant)
+        return (commit, new_variant)
 
     def get_selected_values(n):
         lst = []
         for i in range(n):
             # create the selectbox in columns
-            host_val = containers[i][0].selectbox('hostname', benches.structure.keys(), key = str(i) + '0_sequential')
-            timestamp_val = containers[i][1].selectbox('timestamp', benches.structure[host_val].keys(), key = str(i) + '1_sequential')
-            commit_variant_tuple_lst = unzip_dict((benches.structure[host_val][timestamp_val]).items())
+            host_val = containers[i][0].selectbox(
+                "hostname", benches.structure.keys(), key=str(i) + "0_sequential"
+            )
+            timestamp_val = containers[i][1].selectbox(
+                "timestamp",
+                benches.structure[host_val].keys(),
+                key=str(i) + "1_sequential",
+            )
+            commit_variant_tuple_lst = unzip_dict(
+                (benches.structure[host_val][timestamp_val]).items()
+            )
             # st.write(commit_variant_tuple_lst)
-            fmtted_variants = [fmt_variant(c, v) for c,v in commit_variant_tuple_lst]
+            fmtted_variants = [fmt_variant(c, v) for c, v in commit_variant_tuple_lst]
             fmtted_variants = flatten(fmtted_variants)
             # st.write(fmtted_variants)
-            variant_val = containers[i][2].selectbox('variant', fmtted_variants, key = str(i) + '2_sequential')
+            variant_val = containers[i][2].selectbox(
+                "variant", fmtted_variants, key=str(i) + "2_sequential"
+            )
             selected_commit, selected_variant = unfmt_variant(variant_val)
-            lst.append({"host" : host_val, "timestamp" : timestamp_val, "commit" : selected_commit, "variant" : selected_variant})
+            lst.append(
+                {
+                    "host": host_val,
+                    "timestamp": timestamp_val,
+                    "commit": selected_commit,
+                    "variant": selected_variant,
+                }
+            )
         return lst
 
-    selected_benches = benchstruct.BenchStruct("parallel", artifacts_dir, "_1.orunchrt.summary.bench")
-    _ = [selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"]) for f in get_selected_values(n)]
+    selected_benches = benchstruct.BenchStruct(
+        "parallel", artifacts_dir, "_1.orunchrt.summary.bench"
+    )
+    _ = [
+        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
+        for f in get_selected_values(n)
+    ]
     selected_benches.sort()
-
 
     # Expander for showing bench files
     st.subheader("Selected Benchmarks")
@@ -99,85 +128,107 @@ def app():
             data = []
             for l in f:
                 temp = json.loads(l)
-                if 'name' in temp:
+                if "name" in temp:
                     data.append(temp)
             df = pd.json_normalize(data)
-            value     = file.split('/' + benches.config["bench_type"] + '/')[1]
-            date      = value.split('/')[1].split('_')[0]
-            commit_id = value.split('/')[2][:7]
-            variant   = value.split('/')[3].split('_')[0]
-            df["variant"] = variant + '_' + date + '_' + commit_id
+            value = file.split("/" + benches.config["bench_type"] + "/")[1]
+            date = value.split("/")[1].split("_")[0]
+            commit_id = value.split("/")[2][:7]
+            variant = value.split("/")[3].split("_")[0]
+            df["variant"] = variant + "_" + date + "_" + commit_id
 
         return df
 
-
     def get_dataframes_from_files(files):
         data_frames = [get_dataframe(file) for file in files]
-        df = pd.concat (data_frames, sort=False)
-        df = df.sort_values(['name', 'time_secs'])
+        df = pd.concat(data_frames, sort=False)
+        df = df.sort_values(["name", "time_secs"])
         return df
 
     df = get_dataframes_from_files(selected_files)
 
-    def renameLabel(n,topic=""):
-        n = n.replace("name = ","")
-        if (topic==""):
-            return re.sub("_multicore\..*","",n)
-        return re.sub("_multicore\..*","",n) + " (" + str(mdf.loc[mdf['name'] == n]['b'+topic].values[0]) + ")"
+    def renameLabel(n, topic=""):
+        n = n.replace("name = ", "")
+        if topic == "":
+            return re.sub("_multicore\..*", "", n)
+        return (
+            re.sub("_multicore\..*", "", n)
+            + " ("
+            + str(mdf.loc[mdf["name"] == n]["b" + topic].values[0])
+            + ")"
+        )
 
-    def getFastestSequential(df,topic):
+    def getFastestSequential(df, topic):
         fastest_sequential = {}
-        for g in df.groupby(['name']):
-            (n,d) = g
+        for g in df.groupby(["name"]):
+            (n, d) = g
             fastest_sequential[n] = min(list(d[topic]))
         return fastest_sequential
 
     def normalize(sdf, mdf, topic):
         frames = []
         fastest_sequential = getFastestSequential(sdf, topic)
-        for g in mdf.groupby('name'):
-            (n,d) = g
-            n = n.replace('_multicore','')
-            d['n'+topic] = 1 / d[topic].div(fastest_sequential[n],axis=0)
-            d['b'+topic] = int(fastest_sequential[n])
+        for g in mdf.groupby("name"):
+            (n, d) = g
+            n = n.replace("_multicore", "")
+            d["n" + topic] = 1 / d[topic].div(fastest_sequential[n], axis=0)
+            d["b" + topic] = int(fastest_sequential[n])
             frames.append(d)
         return pd.concat(frames, ignore_index=True)
 
-
     # Sequential runs
-    sdf = df.loc[~df['name'].str.contains('multicore',regex=False),:]
+    sdf = df.loc[~df["name"].str.contains("multicore", regex=False), :]
     throughput_sdf = pd.DataFrame.copy(sdf)
     with st.expander("Show Raw data (sequential runs)"):
         st.write(sdf)
 
     # Multicore runs
-    mdf = df.loc[df['name'].str.contains('multicore',regex=False),:]
-    mdf['num_domains'] = mdf['name'].str.split('.',expand=True)[1].str.split('_',expand=True)[0]
-    mdf['num_domains'] = pd.to_numeric(mdf['num_domains'])
-    mdf['name'] = mdf['name'].replace('\..*?_','.',regex=True)
+    mdf = df.loc[df["name"].str.contains("multicore", regex=False), :]
+    mdf["num_domains"] = (
+        mdf["name"].str.split(".", expand=True)[1].str.split("_", expand=True)[0]
+    )
+    mdf["num_domains"] = pd.to_numeric(mdf["num_domains"])
+    mdf["name"] = mdf["name"].replace("\..*?_", ".", regex=True)
 
-    mdf = normalize(sdf,mdf,"time_secs")
+    mdf = normalize(sdf, mdf, "time_secs")
     throughput_mdf = pd.DataFrame.copy(mdf)
     with st.expander("Show Raw data (multicore runs)"):
         st.write(mdf)
     # mdf.sort_values(['name','variant','num_domains'])
 
-    #mdf = mdf.sort_values(['name'])
+    # mdf = mdf.sort_values(['name'])
     # #mdf = mdf[~mdf.index.duplicated()]
-    #time_g = sns.relplot(x='num_domains', y = 'time_secs', hue='variant', col='name',
+    # time_g = sns.relplot(x='num_domains', y = 'time_secs', hue='variant', col='name',
     #        data=mdf, kind='line', style='variant', markers=True, col_wrap = 4,
     #        lw=5, palette="muted")
 
-    #st.header("Time")
-    #st.pyplot(time_g)
+    # st.header("Time")
+    # st.pyplot(time_g)
 
-    mdf = mdf.sort_values(['name'])
-    with sns.plotting_context(rc={"font.size":14,"axes.titlesize":14,"axes.labelsize":14, "legend.fontsize":14}):
-        speedup_g = sns.relplot(x='num_domains', y = 'ntime_secs', hue='variant', col='name',
-                data=mdf, kind='line', style='variant', markers=True, col_wrap = 3,
-                lw=3, height=3)
+    mdf = mdf.sort_values(["name"])
+    with sns.plotting_context(
+        rc={
+            "font.size": 14,
+            "axes.titlesize": 14,
+            "axes.labelsize": 14,
+            "legend.fontsize": 14,
+        }
+    ):
+        speedup_g = sns.relplot(
+            x="num_domains",
+            y="ntime_secs",
+            hue="variant",
+            col="name",
+            data=mdf,
+            kind="line",
+            style="variant",
+            markers=True,
+            col_wrap=3,
+            lw=3,
+            height=3,
+        )
         for ax in speedup_g.axes:
-            ax.set_title(renameLabel(ax.title.get_text(),"time_secs"))
+            ax.set_title(renameLabel(ax.title.get_text(), "time_secs"))
             ax.set_ylabel("Speedup")
 
     st.header("Speedup")

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -14,346 +14,401 @@ import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
 
+
 def app():
-	st.title("Sequential Benchmarks")
+    st.title("Sequential Benchmarks")
 
-	# Problem : right now the structure is a nested dict of
-	#     `(hostname * (timestamp * (variants list)) dict ) dict`
-	# and this nested structure although works but it is a bit difficult to work with
-	# so we need to create a class object which is a record type and add functions to 
+    # Problem : right now the structure is a nested dict of
+    #     `(hostname * (timestamp * (variants list)) dict ) dict`
+    # and this nested structure although works but it is a bit difficult to work with
+    # so we need to create a class object which is a record type and add functions to
 
-	# <host 1>
-	# |--- <timestamp 1>
-	#         |--- <commit 1>
-	#                 |--- <variant 1>
-	#                 |--- <variant 2>
-	#                 ....
-	#                 ....
-	#                 ....
-	#                 |--- <variant n>
-	#         |--- <commit 2>
-	#                 ....
-	#                 ....
-	#                 ....
-	#         ....
-	#         ....
-	#         ....
-	#         |--- <commit n>
-	#                 ....
-	#                 ....
-	#                 ....
-	# ....
-	# ....
-	# ....
-	# ....
-	# |--- <timestamp n>
-	#         ....
-	#         ....
-	# <host 2>
-	# ....
-	# ....
-	# ....
-	# <host n>
+    # <host 1>
+    # |--- <timestamp 1>
+    #         |--- <commit 1>
+    #                 |--- <variant 1>
+    #                 |--- <variant 2>
+    #                 ....
+    #                 ....
+    #                 ....
+    #                 |--- <variant n>
+    #         |--- <commit 2>
+    #                 ....
+    #                 ....
+    #                 ....
+    #         ....
+    #         ....
+    #         ....
+    #         |--- <commit n>
+    #                 ....
+    #                 ....
+    #                 ....
+    # ....
+    # ....
+    # ....
+    # ....
+    # |--- <timestamp n>
+    #         ....
+    #         ....
+    # <host 2>
+    # ....
+    # ....
+    # ....
+    # <host n>
 
-	current = os.getcwd().split('/')
-	current.pop()
-	artifacts_dir = '/'.join(current) + '/sandmark-nightly'
-	# print(artifacts_dir)
-	benches = benchstruct.BenchStruct("sequential", artifacts_dir, "_1.orun.summary.bench")
-	benches.add_files(benches.get_bench_files())
-	benches.sort()
+    current = os.getcwd().split("/")
+    current.pop()
+    artifacts_dir = "/".join(current) + "/sandmark-nightly"
+    # print(artifacts_dir)
+    benches = benchstruct.BenchStruct(
+        "sequential", artifacts_dir, "_1.orun.summary.bench"
+    )
+    benches.add_files(benches.get_bench_files())
+    benches.sort()
 
-	st.header("Select variants")
-	n = int(st.text_input('Number of variants','2', key=benches.config["bench_type"]))
+    st.header("Select variants")
+    n = int(st.text_input("Number of variants", "2", key=benches.config["bench_type"]))
 
-	containers = [st.columns(3) for i in range(n)]
+    containers = [st.columns(3) for i in range(n)]
 
-	# [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
-	def flatten(lst):
-		return reduce(lambda a, b: a + b, lst)
+    # [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
+    def flatten(lst):
+        return reduce(lambda a, b: a + b, lst)
 
-	# [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
-	def unzip(lst):
-		return (list(zip(*lst)))
+    # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
+    def unzip(lst):
+        return list(zip(*lst))
 
-	def unzip_dict(d):
-		a = unzip(list(d))
-		# st.write(a)
-		commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
-		return commit_variant_tuple_lst
+    def unzip_dict(d):
+        a = unzip(list(d))
+        # st.write(a)
+        commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
+        return commit_variant_tuple_lst
 
-	def fmt_variant(commit, variant_lst):
-		# st.write(commit)
-		# st.write(variant)
-		def fmt(commit, variant):
-			variant_name = variant.split('_')[0]
-			commit_id = str(commit)
-			variant_tail = variant.split('_')[1]
-			return (variant.split('_')[0] + '+' + str(commit) + '_' + variant.split('_')[1])
-		fmt_variant_lst = [fmt(commit, v) for v in variant_lst]
-		return fmt_variant_lst
+    def fmt_variant(commit, variant_lst):
+        # st.write(commit)
+        # st.write(variant)
+        def fmt(commit, variant):
+            variant_name = variant.split("_")[0]
+            commit_id = str(commit)
+            variant_tail = variant.split("_")[1]
+            return (
+                variant.split("_")[0] + "+" + str(commit) + "_" + variant.split("_")[1]
+            )
 
+        fmt_variant_lst = [fmt(commit, v) for v in variant_lst]
+        return fmt_variant_lst
 
-	def unfmt_variant(variant):
-		commit = variant.split('_')[0].split('+')[-1]
-		variant_root = variant.split('_')[1]
-		variant_stem = variant.split('_')[0].split('+')
-		variant_stem.pop()
-		variant_stem = reduce(lambda a, b: b if a == "" else a + "+" + b, variant_stem, "")
-		new_variant = variant_stem + '_' + variant_root
-		# st.write(new_variant)
-		return (commit , new_variant)
+    def unfmt_variant(variant):
+        commit = variant.split("_")[0].split("+")[-1]
+        variant_root = variant.split("_")[1]
+        variant_stem = variant.split("_")[0].split("+")
+        variant_stem.pop()
+        variant_stem = reduce(
+            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
+        )
+        new_variant = variant_stem + "_" + variant_root
+        # st.write(new_variant)
+        return (commit, new_variant)
 
-	def get_selected_values(n):
-		lst = []
-		for i in range(n):
-			# create the selectbox in columns
-			host_val = containers[i][0].selectbox('hostname', benches.structure.keys(), key = str(i) + '0_' + benches.config["bench_type"])
-			timestamp_val = containers[i][1].selectbox('timestamp', benches.structure[host_val].keys(), key = str(i) + '1_' + benches.config["bench_type"])
-			# st.write(benches.structure)
-			commit_variant_tuple_lst = unzip_dict((benches.structure[host_val][timestamp_val]).items())
-			fmtted_variants = [fmt_variant(c, v) for c,v in commit_variant_tuple_lst]
-			# st.write("formatted variants")
-			fmtted_variants = flatten(fmtted_variants)
-			# st.write(fmtted_variants)
-			variant_val = containers[i][2].selectbox('variant', fmtted_variants, key = str(i) + '2_' + benches.config["bench_type"])
-			selected_commit, selected_variant = unfmt_variant(variant_val)
-			lst.append({"host" : host_val, "timestamp" : timestamp_val, "commit" : selected_commit, "variant" : selected_variant})
-		return lst
+    def get_selected_values(n):
+        lst = []
+        for i in range(n):
+            # create the selectbox in columns
+            host_val = containers[i][0].selectbox(
+                "hostname",
+                benches.structure.keys(),
+                key=str(i) + "0_" + benches.config["bench_type"],
+            )
+            timestamp_val = containers[i][1].selectbox(
+                "timestamp",
+                benches.structure[host_val].keys(),
+                key=str(i) + "1_" + benches.config["bench_type"],
+            )
+            # st.write(benches.structure)
+            commit_variant_tuple_lst = unzip_dict(
+                (benches.structure[host_val][timestamp_val]).items()
+            )
+            fmtted_variants = [fmt_variant(c, v) for c, v in commit_variant_tuple_lst]
+            # st.write("formatted variants")
+            fmtted_variants = flatten(fmtted_variants)
+            # st.write(fmtted_variants)
+            variant_val = containers[i][2].selectbox(
+                "variant",
+                fmtted_variants,
+                key=str(i) + "2_" + benches.config["bench_type"],
+            )
+            selected_commit, selected_variant = unfmt_variant(variant_val)
+            lst.append(
+                {
+                    "host": host_val,
+                    "timestamp": timestamp_val,
+                    "commit": selected_commit,
+                    "variant": selected_variant,
+                }
+            )
+        return lst
 
-	selected_benches = benchstruct.BenchStruct("sequential", artifacts_dir, "_1.orun.summary.bench")
-	_ = [selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"]) for f in get_selected_values(n)]
-	selected_benches.sort()
+    selected_benches = benchstruct.BenchStruct(
+        "sequential", artifacts_dir, "_1.orun.summary.bench"
+    )
+    _ = [
+        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
+        for f in get_selected_values(n)
+    ]
+    selected_benches.sort()
 
-	# Expander for showing bench files
-	st.subheader("Benchmarks Selected")
-	st.write(selected_benches.display())
+    # Expander for showing bench files
+    st.subheader("Benchmarks Selected")
+    st.write(selected_benches.display())
 
-	selected_files = flatten(selected_benches.to_filepath())
+    selected_files = flatten(selected_benches.to_filepath())
 
-	unique_num_selected_files = len(set(selected_files))
+    unique_num_selected_files = len(set(selected_files))
 
-	normalization_state = True
+    normalization_state = True
 
-	if unique_num_selected_files < len(selected_files):
-		normalization_state = False
+    if unique_num_selected_files < len(selected_files):
+        normalization_state = False
 
-	def dataframe_intersection(data_frames):
-		intersection_set_list = [set(df['name']) for df in data_frames]
-		list_diff = list(reduce(lambda x, y: x.intersection(y), intersection_set_list))
-		new_data_frames = []
-		for elem in list_diff:
-			for df in data_frames:
-				new_data_frames.append(df[(df.name == elem)])
-		list_diff.sort()
-		# st.write(list_diff)
-		return new_data_frames
+    def dataframe_intersection(data_frames):
+        intersection_set_list = [set(df["name"]) for df in data_frames]
+        list_diff = list(reduce(lambda x, y: x.intersection(y), intersection_set_list))
+        new_data_frames = []
+        for elem in list_diff:
+            for df in data_frames:
+                new_data_frames.append(df[(df.name == elem)])
+        list_diff.sort()
+        # st.write(list_diff)
+        return new_data_frames
 
-	def get_dataframe(file):
-		# json to dataframe
-		# st.write(file)
-		with open(file) as f:
-			data = []
-			for l in f:
-				temp = json.loads(l)
-				#check if the benchmark json contains name field
-				#avoids crashing if the entry doesn't contain a benchmark
-				if 'name' in temp:
-					data.append(temp)
-			df = pd.json_normalize(data)
-			value     = file.split('/' + benches.config["bench_type"] + '/')[1]
-			date      = value.split('/')[1].split('_')[0]
-			commit_id = value.split('/')[2][:7]
-			variant   = value.split('/')[3].split('_')[0]
-			df["variant"] = variant + '_' + date + '_' + commit_id
-		return df
+    def get_dataframe(file):
+        # json to dataframe
+        # st.write(file)
+        with open(file) as f:
+            data = []
+            for l in f:
+                temp = json.loads(l)
+                # check if the benchmark json contains name field
+                # avoids crashing if the entry doesn't contain a benchmark
+                if "name" in temp:
+                    data.append(temp)
+            df = pd.json_normalize(data)
+            value = file.split("/" + benches.config["bench_type"] + "/")[1]
+            date = value.split("/")[1].split("_")[0]
+            commit_id = value.split("/")[2][:7]
+            variant = value.split("/")[3].split("_")[0]
+            df["variant"] = variant + "_" + date + "_" + commit_id
+        return df
 
+    def get_dataframes_from_files(files):
+        data_frames = [get_dataframe(file) for file in files]
+        new_data_frames = dataframe_intersection(data_frames=data_frames)
+        df = pd.concat(new_data_frames, sort=False)
+        # st.write(df)
+        df.sort_values(["name"])
+        return df
 
+    def plot(df, y_axis):
+        graph = sns.catplot(
+            x="name", y=y_axis, hue="variant", data=df, kind="bar", aspect=4
+        )
+        graph.set_xticklabels(rotation=90)
+        return graph
 
-	def get_dataframes_from_files(files):
-		data_frames = [get_dataframe(file) for file in files]
-		new_data_frames = dataframe_intersection(data_frames=data_frames)
-		df = pd.concat(new_data_frames, sort=False)
-		# st.write(df)
-		df.sort_values(['name'])
-		return df
+    def fmt_baseline(record):
+        date = record["timestamp"].split("_")[0]
+        commit = record["commit"][:7]
+        variant = record["variant"].split("_")[0]
+        s = str(variant) + "_" + date + "_" + commit
+        return s
 
-	def plot(df, y_axis):
-		graph = sns.catplot (
-			x = "name",
-			y = y_axis,
-			hue = "variant",
-			data = df,
-			kind = "bar",
-			aspect = 4
-		)
-		graph.set_xticklabels(rotation=90)
-		return graph
+    def create_column(df, variant, metric):
+        df = pd.DataFrame.copy(df)
+        variant_metric_name = list(
+            [
+                zip(df[metric], df[x], df["name"])
+                for x in df.columns.array
+                if x == "variant"
+            ][0]
+        )
+        # st.write(df)
+        # st.write(variant)
+        name_metric = {n: t for (t, v, n) in variant_metric_name if v == variant}
+        return name_metric
 
-	def fmt_baseline(record):
-		date = record["timestamp"].split('_')[0]
-		commit = record["commit"][:7]
-		variant = record["variant"].split('_')[0]
-		s = str(variant) + '_' + date + '_' + commit
-		return s
+    def add_display_name(df, variant, metric):
+        name_metric = create_column(pd.DataFrame.copy(df), variant, metric)
+        disp_name = [
+            name + " (" + str(round(name_metric[name], 2)) + ")" for name in df["name"]
+        ]
+        df["display_name"] = pd.Series(disp_name, index=df.index)
+        return df
 
-	def create_column(df, variant, metric):
-		df = pd.DataFrame.copy(df)
-		variant_metric_name = list([ zip(df[metric], df[x], df['name'])
-				for x in df.columns.array if x == "variant" ][0])
-		# st.write(df)
-		# st.write(variant)
-		name_metric = {n:t for (t, v, n) in variant_metric_name if v == variant}
-		return name_metric
+    def normalise(df, variant, topic, normalization_state, additionalTopics=[]):
+        if not normalization_state:
+            st.error(
+                "Redundant variants selected, please choose unique variants to compare"
+            )
+            return pd.DataFrame()
 
-	def add_display_name(df,variant, metric):
-		name_metric = create_column(pd.DataFrame.copy(df), variant, metric)
-		disp_name = [name+" ("+str(round(name_metric[name], 2))+")" for name in df["name"]]
-		df["display_name"] = pd.Series(disp_name, index=df.index)
-		return df
+        else:
+            st.write(normalization_state)
+            df = add_display_name(df, variant, topic)
+            df = df.sort_values(["name", "variant"])
+            grouped = df.filter(
+                items=["name", topic, "variant", "display_name"] + additionalTopics
+            ).groupby("variant")
+            ndata_frames = []
+            # st.write(grouped)
+            for group in grouped:
+                (v, data) = group
+                if v != variant:
+                    data["b" + topic] = grouped.get_group(variant)[topic].values
+                    data[["n" + topic]] = data[[topic]].div(
+                        grouped.get_group(variant)[topic].values, axis=0
+                    )
+                    for t in additionalTopics:
+                        data[[t]] = grouped.get_group(variant)[t].values
+                    ndata_frames.append(data)
+                    # st.write(data)
+                else:
+                    continue
+            if ndata_frames:
+                df = pd.concat(ndata_frames)
+                return df
+            else:
+                st.warning(
+                    "Variants selected are the same, please select different variants to generate a normalized graph"
+                )
+                return pd.DataFrame()
 
-	def normalise(df,variant,topic, normalization_state, additionalTopics=[]):
-		if not normalization_state:
-			st.error("Redundant variants selected, please choose unique variants to compare")
-			return pd.DataFrame()
-		
-		else:
-			st.write(normalization_state)
-			df = add_display_name(df,variant,topic)
-			df = df.sort_values(["name","variant"])
-			grouped = df.filter(items=['name',topic,'variant','display_name']+additionalTopics).groupby('variant')
-			ndata_frames = []
-			# st.write(grouped)
-			for group in grouped:
-				(v,data) = group
-				if(v != variant):
-					data['b'+topic] = grouped.get_group(variant)[topic].values
-					data[['n'+topic]] = data[[topic]].div(grouped.get_group(variant)[topic].values, axis=0)
-					for t in additionalTopics:
-						data[[t]] = grouped.get_group(variant)[t].values
-					ndata_frames.append(data)
-					# st.write(data)
-				else:
-					continue
-			if ndata_frames:
-				df = pd.concat(ndata_frames)
-				return df
-			else:
-				st.warning("Variants selected are the same, please select different variants to generate a normalized graph")
-				return pd.DataFrame()
+    def plot_normalised(baseline, df, topic):
+        xlabel = "Benchmarks (baseline = " + baseline + ")"
+        if not df.empty:
+            df = pd.DataFrame.copy(df)
+            df.sort_values(by=[topic], inplace=True)
+            df[topic] = df[topic] - 1
+            g = sns.catplot(
+                x="display_name",
+                y=topic,
+                hue="variant",
+                data=df,
+                kind="bar",
+                aspect=4,
+                bottom=1,
+            )
+            g.set_xticklabels(rotation=90)
+            g.ax.legend(loc=8)
+            g._legend.remove()
+            g.ax.set_xlabel(xlabel)
+            return g
 
-	def plot_normalised(baseline, df, topic):
-		xlabel = "Benchmarks (baseline = " + baseline + ")"
-		if not df.empty:
-			df = pd.DataFrame.copy(df)
-			df.sort_values(by=[topic],inplace=True)
-			df[topic] = df[topic] - 1
-			g = sns.catplot (x="display_name", y=topic, hue='variant', data = df, kind ='bar', aspect=4, bottom=1)
-			g.set_xticklabels(rotation=90)
-			g.ax.legend(loc=8)
-			g._legend.remove()
-			g.ax.set_xlabel(xlabel)
-			return g
-	
-	df = get_dataframes_from_files(selected_files)
-	# df = df.drop_duplicates(subset=['name','variant'])
+    df = get_dataframes_from_files(selected_files)
+    # df = df.drop_duplicates(subset=['name','variant'])
 
+    st.header("Select baseline (for normalized graphs)")
+    baseline_container = st.columns(3)
+    baseline_host = baseline_container[0].selectbox(
+        "hostname",
+        selected_benches.structure.keys(),
+        key="B0_" + benches.config["bench_type"],
+    )
+    baseline_timestamp = baseline_container[1].selectbox(
+        "timestamp",
+        selected_benches.structure[baseline_host].keys(),
+        key="B1_" + benches.config["bench_type"],
+    )
+    baseline_commit_variants_tuples_lst = unzip_dict(
+        (selected_benches.structure[baseline_host][baseline_timestamp]).items()
+    )
 
-	st.header("Select baseline (for normalized graphs)")
-	baseline_container = st.columns(3)
-	baseline_host = baseline_container[0].selectbox(
-		'hostname', 
-		selected_benches.structure.keys(),
-		key = 'B0_' + benches.config["bench_type"])
-	baseline_timestamp = baseline_container[1].selectbox(
-		'timestamp', 
-		selected_benches.structure[baseline_host].keys(),
-		key = 'B1_' + benches.config["bench_type"])    
-	baseline_commit_variants_tuples_lst = unzip_dict((selected_benches.structure[baseline_host][baseline_timestamp]).items())
+    fmtted_variants = [
+        fmt_variant(c, v) for c, v in baseline_commit_variants_tuples_lst
+    ]
+    fmtted_variants = set(flatten(fmtted_variants))
+    # st.write(fmtted_variants)
+    variant_val = baseline_container[2].selectbox(
+        "variant", fmtted_variants, key="B2_" + benches.config["bench_type"]
+    )
+    baseline_commit, baseline_variant = unfmt_variant(variant_val)
 
-	fmtted_variants = [fmt_variant(c, v) for c,v in baseline_commit_variants_tuples_lst]
-	fmtted_variants = set(flatten(fmtted_variants))
-	# st.write(fmtted_variants)
-	variant_val = baseline_container[2].selectbox('variant', fmtted_variants, key = 'B2_' + benches.config["bench_type"])
-	baseline_commit, baseline_variant = unfmt_variant(variant_val)
+    baseline_record = {
+        "host": baseline_host,
+        "timestamp": baseline_timestamp,
+        "commit": baseline_commit,
+        "variant": baseline_variant,
+    }
 
-	baseline_record = {
-		"host" : baseline_host,
-		"timestamp" : baseline_timestamp,
-		"commit" : baseline_commit,
-		"variant" : baseline_variant
-	}
+    # FIXME : coq fails to build on domains
+    # df = df[(df.name != 'coq.BasicSyntax.v') & (df.name != 'coq.AbstractInterpretation.v')]
 
+    baseline = fmt_baseline(baseline_record)
 
-	# FIXME : coq fails to build on domains
-	# df = df[(df.name != 'coq.BasicSyntax.v') & (df.name != 'coq.AbstractInterpretation.v')]
+    # Display Components
 
-	baseline = fmt_baseline(baseline_record)
+    st.header("Time")
+    with st.expander("Data"):
+        st.write(df)
+    with st.expander("Graph"):
+        st.pyplot(plot(df.copy(), "time_secs"))
 
-	# Display Components
+    ndf = normalise(df.copy(), baseline, "time_secs", normalization_state)
+    st.header("Normalized Time")
+    with st.expander("Data"):
+        st.write(ndf)
+    with st.expander("Graph"):
+        g = plot_normalised(baseline, ndf, "ntime_secs")
+        st.pyplot(g)
 
-	st.header("Time")
-	with st.expander("Data"):
-		st.write(df)
-	with st.expander("Graph"):
-		st.pyplot(plot(df.copy(), 'time_secs'))
+    st.header("Top heap words")
+    with st.expander("Data"):
+        st.write(df)
+    with st.expander("Graph"):
+        st.pyplot(plot(df.copy(), "gc.top_heap_words"))
+    ndf = normalise(df.copy(), baseline, "gc.top_heap_words", normalization_state)
+    st.header("Normalized top heap words")
+    with st.expander("Data"):
+        st.write(ndf)
+    with st.expander("Graph"):
+        g = plot_normalised(baseline, ndf, "ngc.top_heap_words")
+        st.pyplot(g)
 
-	ndf = normalise(df.copy(), baseline, 'time_secs', normalization_state)
-	st.header("Normalized Time")
-	with st.expander("Data"):
-		st.write(ndf)
-	with st.expander("Graph"):
-		g = plot_normalised(baseline, ndf,'ntime_secs')
-		st.pyplot(g)
+    st.header("Max RSS (KB)")
+    with st.expander("Data"):
+        st.write(df)
+    with st.expander("Graph"):
+        st.pyplot(plot(df.copy(), "maxrss_kB"))
+    ndf = normalise(df.copy(), baseline, "maxrss_kB", normalization_state)
+    st.header("Normalized Max RSS (KB)")
+    with st.expander("Data"):
+        st.write(ndf)
+    with st.expander("Graph"):
+        g = plot_normalised(baseline, ndf, "nmaxrss_kB")
+        st.pyplot(g)
 
-	st.header("Top heap words")
-	with st.expander("Data"):
-		st.write(df)
-	with st.expander("Graph"):
-		st.pyplot(plot(df.copy(), 'gc.top_heap_words'))
-	ndf = normalise(df.copy(), baseline, 'gc.top_heap_words', normalization_state)
-	st.header("Normalized top heap words")
-	with st.expander("Data"):
-		st.write(ndf)
-	with st.expander("Graph"):
-		g = plot_normalised(baseline, ndf, 'ngc.top_heap_words')
-		st.pyplot(g)
+    st.header("Major Collections")
+    with st.expander("Data"):
+        st.write(df)
+    with st.expander("Graph"):
+        st.pyplot(plot(df.copy(), "gc.major_collections"))
+    ndf = normalise(df.copy(), baseline, "gc.major_collections", normalization_state)
+    st.header("Normalized major collections")
+    with st.expander("Data"):
+        st.write(ndf)
+    with st.expander("Graph"):
+        g = plot_normalised(baseline, ndf, "ngc.major_collections")
+        st.pyplot(g)
 
-	st.header("Max RSS (KB)")
-	with st.expander("Data"):
-		st.write(df)
-	with st.expander("Graph"):
-		st.pyplot(plot(df.copy(), "maxrss_kB"))
-	ndf = normalise(df.copy(), baseline, 'maxrss_kB', normalization_state)
-	st.header("Normalized Max RSS (KB)")
-	with st.expander("Data"):
-		st.write(ndf)
-	with st.expander("Graph"):
-		g = plot_normalised(baseline, ndf, 'nmaxrss_kB')
-		st.pyplot(g)
-
-	st.header("Major Collections")
-	with st.expander("Data"):
-		st.write(df)
-	with st.expander("Graph"):
-		st.pyplot(plot(df.copy(), "gc.major_collections"))
-	ndf = normalise(df.copy(), baseline, 'gc.major_collections', normalization_state)
-	st.header("Normalized major collections")
-	with st.expander("Data"):
-		st.write(ndf)
-	with st.expander("Graph"):
-		g = plot_normalised(baseline, ndf, 'ngc.major_collections')
-		st.pyplot(g)
-
-	st.header("Minor Collections")
-	with st.expander("Data"):
-		st.write(df)
-	with st.expander("Graph"):
-		st.pyplot(plot(df.copy(), "gc.minor_collections"))
-	ndf = normalise(df.copy(), baseline, 'gc.minor_collections', normalization_state)
-	st.header("Normalized minor collections")
-	with st.expander("Data"):
-		st.write(ndf)
-	with st.expander("Graph"):
-		g = plot_normalised(baseline, ndf, 'ngc.minor_collections')
-		st.pyplot(g)
+    st.header("Minor Collections")
+    with st.expander("Data"):
+        st.write(df)
+    with st.expander("Graph"):
+        st.pyplot(plot(df.copy(), "gc.minor_collections"))
+    ndf = normalise(df.copy(), baseline, "gc.minor_collections", normalization_state)
+    st.header("Normalized minor collections")
+    with st.expander("Data"):
+        st.write(ndf)
+    with st.expander("Graph"):
+        g = plot_normalised(baseline, ndf, "ngc.minor_collections")
+        st.pyplot(g)

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -245,7 +245,7 @@ def app():
         df["display_name"] = pd.Series(disp_name, index=df.index)
         return df
 
-    def normalise(df, variant, topic, normalization_state, additionalTopics=[]):
+    def normalise(df, baseline, topic, normalization_state, additionalTopics=[]):
         if not normalization_state:
             st.error(
                 "Redundant variants selected, please choose unique variants to compare"
@@ -254,7 +254,7 @@ def app():
 
         else:
             st.write(normalization_state)
-            df = add_display_name(df, variant, topic)
+            df = add_display_name(df, baseline, topic)
             df = df.sort_values(["name", "variant"])
             grouped = df.filter(
                 items=["name", topic, "variant", "display_name"] + additionalTopics
@@ -263,13 +263,13 @@ def app():
             # st.write(grouped)
             for group in grouped:
                 (v, data) = group
-                if v != variant:
-                    data["b" + topic] = grouped.get_group(variant)[topic].values
+                if v != baseline:
+                    data["b" + topic] = grouped.get_group(baseline)[topic].values
                     data[["n" + topic]] = data[[topic]].div(
-                        grouped.get_group(variant)[topic].values, axis=0
+                        grouped.get_group(baseline)[topic].values, axis=0
                     )
                     for t in additionalTopics:
-                        data[[t]] = grouped.get_group(variant)[t].values
+                        data[[t]] = grouped.get_group(baseline)[t].values
                     ndata_frames.append(data)
                     # st.write(data)
                 else:

--- a/app/multiapp.py
+++ b/app/multiapp.py
@@ -4,6 +4,7 @@
 """
 import streamlit as st
 
+
 class MultiApp:
     """Framework for combining multiple streamlit applications.
     Usage:
@@ -23,6 +24,7 @@ class MultiApp:
         app.add_app("Bar", bar.app)
         app.run()
     """
+
     def __init__(self):
         self.apps = []
 
@@ -35,15 +37,9 @@ class MultiApp:
         title:
             title of the app. Appears in the dropdown in the sidebar.
         """
-        self.apps.append({
-            "title": title,
-            "function": func
-        })
+        self.apps.append({"title": title, "function": func})
 
     def run(self):
-        app = st.sidebar.radio(
-            'Go To',
-            self.apps,
-            format_func=lambda app: app['title'])
+        app = st.sidebar.radio("Go To", self.apps, format_func=lambda app: app["title"])
 
-        app['function']()
+        app["function"]()


### PR DESCRIPTION
The PR backports changes from the Sandmark notebook to the webapp (https://github.com/ocaml-bench/sandmark/pull/351). The code was slightly changed to improve the detection of duplicated variants when trying to normalise the data. 

Also, I ran into issues when trying to edit the files because they use TABs instead of spaces. It is [recommended](https://peps.python.org/pep-0008/#indentation) to use spaces and is the general convention in the Python world. I used [Black](https://github.com/psf/black) to format the files to make the formatting style easily reproducible by everyone working on this codebase.  I made these formatting changes in a separate commit, but didn't make them in a separate PR, since the repo doesn't have any pending PRs, as of now. 