### PR TITLE
Fix bench file not found error on production webapp

### DIFF
--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -18,10 +18,8 @@ class BenchStruct:
         self.structure[host][timestamp][commit].append(variant)
 
     def add_files(self, files):
-        for x in files:
-            l = x.split(str("/" + self.config["bench_type"] + "/"))[1]
-            d = l.split("/")
-            self.add(d[0], d[1], d[2], d[3])
+        for relative_path in files:
+            self.add(*relative_path.split("/"))
 
     def to_filepath(self):
         lst = []
@@ -46,11 +44,9 @@ class BenchStruct:
         return lst
 
     def get_bench_files(self):
-        dir_ = self.config["artifacts_dir"]
-        bench_type = self.config["bench_type"]
-        stem = self.config["bench_stem"]
-        pattern = f"{dir_}/{bench_type}/**/*{stem}"
-        return glob.glob(pattern, recursive=True)
+        root_dir = f"{self.config['artifacts_dir']}/{self.config['bench_type']}"
+        pattern = f"**/*{self.config['bench_stem']}"
+        return glob.glob(pattern, root_dir=root_dir, recursive=True)
 
     def __repr__(self):
         return f"{self.structure}"

--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -2,6 +2,7 @@ from nested_dict import nested_dict
 import os
 from collections import OrderedDict
 import pandas as pd
+import glob
 
 
 class BenchStruct:
@@ -45,19 +46,11 @@ class BenchStruct:
         return lst
 
     def get_bench_files(self):
-        bench_files = []
-
-        # Loads file metadata
-        for root, dirs, files in os.walk(
-            self.config["artifacts_dir"] + "/" + self.config["bench_type"]
-        ):
-            for file in files:
-                if file.endswith(self.config["bench_stem"]):
-                    f = root.split("/" + self.config["bench_type"])
-                    bench_files.append((os.path.join(root, file)))
-
-        # print(bench_files)
-        return bench_files
+        dir_ = self.config["artifacts_dir"]
+        bench_type = self.config["bench_type"]
+        stem = self.config["bench_stem"]
+        pattern = f"{dir_}/{bench_type}/**/*{stem}"
+        return glob.glob(pattern, recursive=True)
 
     def __repr__(self):
         return f"{self.structure}"

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -48,30 +48,11 @@ def app():
         return commit_variant_tuple_lst
 
     def fmt_variant(commit, variant_lst):
-        # st.write(commit)
-        # st.write(variant)
-        def fmt(commit, variant):
-            variant_name = variant.split("_")[0]
-            commit_id = str(commit)
-            variant_tail = variant.split("_")[1]
-            return (
-                variant.split("_")[0] + "+" + str(commit) + "_" + variant.split("_")[1]
-            )
-
-        fmt_variant_lst = [fmt(commit, v) for v in variant_lst]
+        fmt_variant_lst = [f"{commit};{v}" for v in variant_lst]
         return fmt_variant_lst
 
     def unfmt_variant(variant):
-        commit = variant.split("_")[0].split("+")[-1]
-        variant_root = variant.split("_")[1]
-        variant_stem = variant.split("_")[0].split("+")
-        variant_stem.pop()
-        variant_stem = reduce(
-            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
-        )
-        new_variant = variant_stem + "_" + variant_root
-        # st.write(new_variant)
-        return (commit, new_variant)
+        return variant.split(";", 1)
 
     def get_selected_values(n):
         lst = []

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -86,30 +86,11 @@ def app():
         return commit_variant_tuple_lst
 
     def fmt_variant(commit, variant_lst):
-        # st.write(commit)
-        # st.write(variant)
-        def fmt(commit, variant):
-            variant_name = variant.split("_")[0]
-            commit_id = str(commit)
-            variant_tail = variant.split("_")[1]
-            return (
-                variant.split("_")[0] + "+" + str(commit) + "_" + variant.split("_")[1]
-            )
-
-        fmt_variant_lst = [fmt(commit, v) for v in variant_lst]
+        fmt_variant_lst = [f"{commit};{v}" for v in variant_lst]
         return fmt_variant_lst
 
     def unfmt_variant(variant):
-        commit = variant.split("_")[0].split("+")[-1]
-        variant_root = variant.split("_")[1]
-        variant_stem = variant.split("_")[0].split("+")
-        variant_stem.pop()
-        variant_stem = reduce(
-            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
-        )
-        new_variant = variant_stem + "_" + variant_root
-        # st.write(new_variant)
-        return (commit, new_variant)
+        return variant.split(";", 1)
 
     def get_selected_values(n):
         lst = []


### PR DESCRIPTION
I've simplified the convoluted logic to format the benchmark variant name, to fix this bug. I tried to look at the commit history to try to understand why this was introduced, but I couldn't find any history since most of the change seems to have been introduced in a single commit.  So, I may be breaking a requirement of how the version number should be displayed on the UI, but this should work reliably without depending on file names being in a specific format. 

I've also cleaned up some related code that tries to look for the bench files to be shown in the UI for selection, in separate commits. 