### PR TITLE
Fix parallel UI to undo the aggressive variant & commit formatting

### DIFF
--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
+from apps.utils import fmt_variant, unfmt_variant
 
 
 def app():
@@ -46,13 +47,6 @@ def app():
         # st.write(a)
         commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
         return commit_variant_tuple_lst
-
-    def fmt_variant(commit, variant_lst):
-        fmt_variant_lst = [f"{commit};{v}" for v in variant_lst]
-        return fmt_variant_lst
-
-    def unfmt_variant(variant):
-        return variant.split(";", 1)
 
     def get_selected_values(n):
         lst = []

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
+from apps.utils import fmt_variant, unfmt_variant
 
 
 def app():
@@ -84,14 +85,6 @@ def app():
         # st.write(a)
         commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
         return commit_variant_tuple_lst
-
-    def fmt_variant(commit, variant_lst):
-        return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variant_lst]
-
-    def unfmt_variant(variant):
-        prefix, stem = variant.rsplit("_", 1)
-        name, commit = prefix.rsplit("+", 1)
-        return (commit, f"{name}_{stem}")
 
     def get_selected_values(n):
         lst = []

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -1,0 +1,8 @@
+def fmt_variant(commit, variant_lst):
+    return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variant_lst]
+
+
+def unfmt_variant(variant):
+    prefix, stem = variant.rsplit("_", 1)
+    name, commit = prefix.rsplit("+", 1)
+    return (commit, f"{name}_{stem}")


### PR DESCRIPTION
9188cac05ddfe065783c572260d5c07b8e did not fix the parallel benchmarks UI, and
only fixed the UI for sequential benchmarks. This commit fixes that.

#61 only partially fixed the formatting of variant+commit.