### PR TITLE
Show dropdown for date instead of timestamp when selecting variants

### DIFF
--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -28,7 +28,8 @@ class BenchRun:
         prefix, _ = self.variant.rsplit("_", 1)
         variant = prefix.rstrip(f"+{self.type}")
         hash_ = self.commit[:7]
-        return f"{variant}+{hash_}"
+        date, time = self.timestamp.split("_", 1)
+        return f"{variant}+{hash_}+{time}"
 
 
 class BenchStruct:
@@ -48,7 +49,8 @@ class BenchStruct:
             commit=commit,
             variant=variant,
         )
-        self.structure[host][timestamp].append(run)
+        date, _ = timestamp.split("_", 1)
+        self.structure[host][date].append(run)
 
     def add_files(self, files):
         for relative_path in files:

--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -22,26 +22,21 @@ class BenchStruct:
             self.add(*relative_path.split("/"))
 
     def to_filepath(self):
-        lst = []
+        filepaths = []
         for host, timestamps in self.structure.items():
             for timestamp, commits in timestamps.items():
                 for commit, bench_files in commits.items():
-                    t = [
-                        self.config["artifacts_dir"]
-                        + "/"
-                        + self.config["bench_type"]
-                        + "/"
-                        + str(host)
-                        + "/"
-                        + str(timestamp)
-                        + "/"
-                        + str(commit)
-                        + "/"
-                        + str(bench_file)
-                        for bench_file in bench_files
-                    ]
-                    lst.append(t)
-        return lst
+                    for bench_file in bench_files:
+                        t = os.path.join(
+                            self.config["artifacts_dir"],
+                            self.config["bench_type"],
+                            host,
+                            timestamp,
+                            commit,
+                            bench_file,
+                        )
+                        filepaths.append(t)
+        return filepaths
 
     def get_bench_files(self):
         root_dir = f"{self.config['artifacts_dir']}/{self.config['bench_type']}"

--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -31,14 +31,14 @@ class BenchStruct:
     config = {}
 
     def __init__(self, bench_type, artifacts_dir, bench_stem):
-        self.structure = nested_dict(3, list)
+        self.structure = nested_dict(2, list)
         self.config["bench_type"] = bench_type
         self.config["artifacts_dir"] = artifacts_dir
         self.config["bench_stem"] = bench_stem
 
     def add(self, host, timestamp, commit, variant):
         run = BenchRun(host=host, timestamp=timestamp, commit=commit, variant=variant)
-        self.structure[host][timestamp][commit].append(run)
+        self.structure[host][timestamp].append(run)
 
     def add_files(self, files):
         for relative_path in files:

--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -56,20 +56,13 @@ class BenchStruct:
         self.structure = nested_dict(self.structure)
 
     def display(self):
-        data = list()
+        data = []
         for host_timestamp_commit_tuple, variant_lst in self.structure.items_flat():
             host = host_timestamp_commit_tuple[0]
             timestamp = host_timestamp_commit_tuple[1]
             commit_id = host_timestamp_commit_tuple[2]
-            if len(variant_lst) > 1:
-                temp_lst = [
-                    [host, timestamp, commit_id, variant] for variant in variant_lst
-                ]
-                for l in temp_lst:
-                    data.append(l)
-            else:
-                temp_lst = [host, timestamp, commit_id, variant_lst[0]]
-                data.append(temp_lst)
+            rows = [[host, timestamp, commit_id, variant] for variant in variant_lst]
+            data.extend(rows)
 
         df_data = pd.DataFrame(
             data, columns=["hostname", "timestamp", "commit_id", "variant"]

--- a/app/apps/instrumented_pausetimes_parallel.py
+++ b/app/apps/instrumented_pausetimes_parallel.py
@@ -194,7 +194,7 @@ def app():
     with st.expander("Show metadata of selected benchmarks"):
         st.write(selected_benches.structure)
 
-    selected_files = flatten(selected_benches.to_filepath())
+    selected_files = selected_benches.to_filepath()
 
     def get_dataframe(file):
         # json to dataframe

--- a/app/apps/instrumented_pausetimes_sequential.py
+++ b/app/apps/instrumented_pausetimes_sequential.py
@@ -196,7 +196,7 @@ def app():
     with st.expander("Show metadata of selected benchmarks"):
         st.write(selected_benches.structure)
 
-    selected_files = flatten(selected_benches.to_filepath())
+    selected_files = selected_benches.to_filepath()
 
     def get_dataframe(file):
         # json to dataframe

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -13,17 +13,14 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values
+from apps.utils import get_selected_values, ARTIFACTS_DIR
 
 
 def app():
     st.title("Parallel Benchmarks")
 
-    current = os.getcwd().split("/")
-    current.pop()
-    artifacts_dir = "/".join(current) + "/sandmark-nightly"
     benches = benchstruct.BenchStruct(
-        "parallel", artifacts_dir, "_1.orunchrt.summary.bench"
+        "parallel", ARTIFACTS_DIR, "_1.orunchrt.summary.bench"
     )
     benches.add_files(benches.get_bench_files())
     benches.sort()
@@ -32,7 +29,7 @@ def app():
     n = int(st.text_input("Number of variants", "1", key=benches.config["bench_type"]))
 
     selected_benches = benchstruct.BenchStruct(
-        "parallel", artifacts_dir, "_1.orunchrt.summary.bench"
+        "parallel", ARTIFACTS_DIR, "_1.orunchrt.summary.bench"
     )
     for f in get_selected_values(n, benches):
         selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values, flatten
+from apps.utils import get_selected_values
 
 
 def app():
@@ -42,7 +42,7 @@ def app():
     st.subheader("Selected Benchmarks")
     st.write(selected_benches.display())
 
-    selected_files = flatten(selected_benches.to_filepath())
+    selected_files = selected_benches.to_filepath()
 
     def get_dataframe(file):
         # json to dataframe

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -2,7 +2,6 @@ from re import U, split, sub
 import streamlit as st
 import numpy as np
 import pandas as pd
-from functools import reduce
 
 from nested_dict import nested_dict
 from pprint import pprint
@@ -14,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import fmt_variant, unfmt_variant
+from apps.utils import get_selected_values, flatten
 
 
 def app():
@@ -32,62 +31,11 @@ def app():
     st.header("Select variants")
     n = int(st.text_input("Number of variants", "1", key=benches.config["bench_type"]))
 
-    containers = [st.columns(3) for i in range(n)]
-
-    # [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
-    def flatten(lst):
-        return reduce(lambda a, b: a + b, lst)
-
-    # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
-    def unzip(lst):
-        return list(zip(*lst))
-
-    def unzip_dict(d):
-        a = unzip(list(d))
-        # st.write(a)
-        commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
-        return commit_variant_tuple_lst
-
-    def get_selected_values(n):
-        lst = []
-        for i in range(n):
-            # create the selectbox in columns
-            host_val = containers[i][0].selectbox(
-                "hostname", benches.structure.keys(), key=str(i) + "0_sequential"
-            )
-            timestamp_val = containers[i][1].selectbox(
-                "timestamp",
-                benches.structure[host_val].keys(),
-                key=str(i) + "1_sequential",
-            )
-            commit_variant_tuple_lst = unzip_dict(
-                (benches.structure[host_val][timestamp_val]).items()
-            )
-            # st.write(commit_variant_tuple_lst)
-            fmtted_variants = [fmt_variant(c, v) for c, v in commit_variant_tuple_lst]
-            fmtted_variants = flatten(fmtted_variants)
-            # st.write(fmtted_variants)
-            variant_val = containers[i][2].selectbox(
-                "variant", fmtted_variants, key=str(i) + "2_sequential"
-            )
-            selected_commit, selected_variant = unfmt_variant(variant_val)
-            lst.append(
-                {
-                    "host": host_val,
-                    "timestamp": timestamp_val,
-                    "commit": selected_commit,
-                    "variant": selected_variant,
-                }
-            )
-        return lst
-
     selected_benches = benchstruct.BenchStruct(
         "parallel", artifacts_dir, "_1.orunchrt.summary.bench"
     )
-    _ = [
+    for f in get_selected_values(n, benches):
         selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
-        for f in get_selected_values(n)
-    ]
     selected_benches.sort()
 
     # Expander for showing bench files

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -13,13 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import (
-    fmt_variants,
-    unfmt_variant,
-    flatten,
-    get_selected_values,
-    unzip_dict,
-)
+from apps.utils import flatten, get_selected_values
 
 
 def app():
@@ -223,37 +217,7 @@ def app():
     # df = df.drop_duplicates(subset=['name','variant'])
 
     st.header("Select baseline (for normalized graphs)")
-    baseline_container = st.columns(3)
-    baseline_host = baseline_container[0].selectbox(
-        "hostname",
-        selected_benches.structure.keys(),
-        key="B0_" + benches.config["bench_type"],
-    )
-    baseline_timestamp = baseline_container[1].selectbox(
-        "timestamp",
-        selected_benches.structure[baseline_host].keys(),
-        key="B1_" + benches.config["bench_type"],
-    )
-    baseline_commit_variants_tuples_lst = unzip_dict(
-        (selected_benches.structure[baseline_host][baseline_timestamp]).items()
-    )
-
-    fmtted_variants = [
-        fmt_variants(c, v) for c, v in baseline_commit_variants_tuples_lst
-    ]
-    fmtted_variants = set(flatten(fmtted_variants))
-    # st.write(fmtted_variants)
-    variant_val = baseline_container[2].selectbox(
-        "variant", fmtted_variants, key="B2_" + benches.config["bench_type"]
-    )
-    baseline_commit, baseline_variant = unfmt_variant(variant_val)
-
-    baseline_record = {
-        "host": baseline_host,
-        "timestamp": baseline_timestamp,
-        "commit": baseline_commit,
-        "variant": baseline_variant,
-    }
+    baseline_record = get_selected_values(1, selected_benches, key_prefix="B")[0]
 
     # FIXME : coq fails to build on domains
     # df = df[(df.name != 'coq.BasicSyntax.v') & (df.name != 'coq.AbstractInterpretation.v')]

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import flatten, get_selected_values
+from apps.utils import get_selected_values
 
 
 def app():
@@ -80,7 +80,7 @@ def app():
     st.subheader("Benchmarks Selected")
     st.write(selected_benches.display())
 
-    selected_files = flatten(selected_benches.to_filepath())
+    selected_files = selected_benches.to_filepath()
 
     unique_num_selected_files = len(set(selected_files))
 

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -14,7 +14,7 @@ import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
 from apps.utils import (
-    fmt_variant,
+    fmt_variants,
     unfmt_variant,
     flatten,
     get_selected_values,
@@ -239,7 +239,7 @@ def app():
     )
 
     fmtted_variants = [
-        fmt_variant(c, v) for c, v in baseline_commit_variants_tuples_lst
+        fmt_variants(c, v) for c, v in baseline_commit_variants_tuples_lst
     ]
     fmtted_variants = set(flatten(fmtted_variants))
     # st.write(fmtted_variants)

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values
+from apps.utils import get_selected_values, ARTIFACTS_DIR
 
 
 def app():
@@ -57,12 +57,8 @@ def app():
     # ....
     # <host n>
 
-    current = os.getcwd().split("/")
-    current.pop()
-    artifacts_dir = "/".join(current) + "/sandmark-nightly"
-    # print(artifacts_dir)
     benches = benchstruct.BenchStruct(
-        "sequential", artifacts_dir, "_1.orun.summary.bench"
+        "sequential", ARTIFACTS_DIR, "_1.orun.summary.bench"
     )
     benches.add_files(benches.get_bench_files())
     benches.sort()
@@ -71,7 +67,7 @@ def app():
     n = int(st.text_input("Number of variants", "2", key=benches.config["bench_type"]))
 
     selected_benches = benchstruct.BenchStruct(
-        "sequential", artifacts_dir, "_1.orun.summary.bench"
+        "sequential", ARTIFACTS_DIR, "_1.orun.summary.bench"
     )
     for f in get_selected_values(n, benches):
         selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -43,11 +43,10 @@ def get_selected_values(n, benches):
             benches.structure[host_val].keys(),
             key=f"{i}1_{benches.config['bench_type']}",
         )
-        commit_variant_tuple_lst = unzip_dict(
-            (benches.structure[host_val][timestamp_val]).items()
-        )
-        fmtted_variants = [fmt_variants(c, v) for c, v in commit_variant_tuple_lst]
-        fmtted_variants = flatten(fmtted_variants)
+        commit_variants = benches.structure[host_val][timestamp_val].items()
+        fmtted_variants = [
+            c_v for c, vs in commit_variants for c_v in fmt_variants(c, vs)
+        ]
         variant_val = containers[i][2].selectbox(
             "variant", fmtted_variants, key=f"{i}2_{benches.config['bench_type']}"
         )

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -18,8 +18,8 @@ def unzip_dict(d):
     return commit_variant_tuple_lst
 
 
-def fmt_variant(commit, variant_lst):
-    return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variant_lst]
+def fmt_variants(commit, variants):
+    return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variants]
 
 
 def unfmt_variant(variant):
@@ -46,7 +46,7 @@ def get_selected_values(n, benches):
         commit_variant_tuple_lst = unzip_dict(
             (benches.structure[host_val][timestamp_val]).items()
         )
-        fmtted_variants = [fmt_variant(c, v) for c, v in commit_variant_tuple_lst]
+        fmtted_variants = [fmt_variants(c, v) for c, v in commit_variant_tuple_lst]
         fmtted_variants = flatten(fmtted_variants)
         variant_val = containers[i][2].selectbox(
             "variant", fmtted_variants, key=f"{i}2_{benches.config['bench_type']}"

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -1,5 +1,9 @@
+import os
 from functools import reduce
 import streamlit as st
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ARTIFACTS_DIR = os.path.join(HERE, "..", "..")
 
 
 def fmt_variants(commit, variants):

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -17,12 +17,12 @@ def get_selected_values(n, benches, key_prefix=""):
             benches.structure.keys(),
             key=f"{prefix}0_{benches.config['bench_type']}",
         )
-        timestamp_val = containers[i][1].selectbox(
-            "timestamp",
+        date_val = containers[i][1].selectbox(
+            "date",
             benches.structure[host_val].keys(),
             key=f"{prefix}1_{benches.config['bench_type']}",
         )
-        runs = [run for run in benches.structure[host_val][timestamp_val]]
+        runs = [run for run in benches.structure[host_val][date_val]]
         selection = containers[i][2].selectbox(
             "variant", runs, key=f"{prefix}2_{benches.config['bench_type']}"
         )

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -1,3 +1,23 @@
+from functools import reduce
+import streamlit as st
+
+# [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
+def flatten(lst):
+    return reduce(lambda a, b: a + b, lst)
+
+
+# [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
+def unzip(lst):
+    return list(zip(*lst))
+
+
+def unzip_dict(d):
+    a = unzip(list(d))
+    # st.write(a)
+    commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
+    return commit_variant_tuple_lst
+
+
 def fmt_variant(commit, variant_lst):
     return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variant_lst]
 
@@ -6,3 +26,38 @@ def unfmt_variant(variant):
     prefix, stem = variant.rsplit("_", 1)
     name, commit = prefix.rsplit("+", 1)
     return (commit, f"{name}_{stem}")
+
+
+def get_selected_values(n, benches):
+    containers = [st.columns(3) for i in range(n)]
+    selections = []
+    for i in range(n):
+        # create the selectbox in columns
+        host_val = containers[i][0].selectbox(
+            "hostname",
+            benches.structure.keys(),
+            key=f"{i}0_{benches.config['bench_type']}",
+        )
+        timestamp_val = containers[i][1].selectbox(
+            "timestamp",
+            benches.structure[host_val].keys(),
+            key=f"{i}1_{benches.config['bench_type']}",
+        )
+        commit_variant_tuple_lst = unzip_dict(
+            (benches.structure[host_val][timestamp_val]).items()
+        )
+        fmtted_variants = [fmt_variant(c, v) for c, v in commit_variant_tuple_lst]
+        fmtted_variants = flatten(fmtted_variants)
+        variant_val = containers[i][2].selectbox(
+            "variant", fmtted_variants, key=f"{i}2_{benches.config['bench_type']}"
+        )
+        selected_commit, selected_variant = unfmt_variant(variant_val)
+        selections.append(
+            {
+                "host": host_val,
+                "timestamp": timestamp_val,
+                "commit": selected_commit,
+                "variant": selected_variant,
+            }
+        )
+    return selections

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -6,18 +6,6 @@ def flatten(lst):
     return reduce(lambda a, b: a + b, lst)
 
 
-# [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
-def unzip(lst):
-    return list(zip(*lst))
-
-
-def unzip_dict(d):
-    a = unzip(list(d))
-    # st.write(a)
-    commit_variant_tuple_lst = [(x1, x2) for x1, x2 in zip(a[0], a[1])]
-    return commit_variant_tuple_lst
-
-
 def fmt_variants(commit, variants):
     return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variants]
 
@@ -28,27 +16,28 @@ def unfmt_variant(variant):
     return (commit, f"{name}_{stem}")
 
 
-def get_selected_values(n, benches):
+def get_selected_values(n, benches, key_prefix=""):
     containers = [st.columns(3) for i in range(n)]
     selections = []
     for i in range(n):
         # create the selectbox in columns
+        prefix = key_prefix or str(i)
         host_val = containers[i][0].selectbox(
             "hostname",
             benches.structure.keys(),
-            key=f"{i}0_{benches.config['bench_type']}",
+            key=f"{prefix}0_{benches.config['bench_type']}",
         )
         timestamp_val = containers[i][1].selectbox(
             "timestamp",
             benches.structure[host_val].keys(),
-            key=f"{i}1_{benches.config['bench_type']}",
+            key=f"{prefix}1_{benches.config['bench_type']}",
         )
         commit_variants = benches.structure[host_val][timestamp_val].items()
         fmtted_variants = [
             c_v for c, vs in commit_variants for c_v in fmt_variants(c, vs)
         ]
         variant_val = containers[i][2].selectbox(
-            "variant", fmtted_variants, key=f"{i}2_{benches.config['bench_type']}"
+            "variant", fmtted_variants, key=f"{prefix}2_{benches.config['bench_type']}"
         )
         selected_commit, selected_variant = unfmt_variant(variant_val)
         selections.append(

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -7,7 +7,7 @@ ARTIFACTS_DIR = os.path.join(HERE, "..", "..")
 
 
 def get_selected_values(n, benches, key_prefix=""):
-    containers = [st.columns(3) for i in range(n)]
+    containers = [st.columns([1, 1, 4]) for i in range(n)]
     selections = []
     for i in range(n):
         # create the selectbox in columns

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -1,10 +1,6 @@
 from functools import reduce
 import streamlit as st
 
-# [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
-def flatten(lst):
-    return reduce(lambda a, b: a + b, lst)
-
 
 def fmt_variants(commit, variants):
     return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variants]

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -22,11 +22,7 @@ def get_selected_values(n, benches, key_prefix=""):
             benches.structure[host_val].keys(),
             key=f"{prefix}1_{benches.config['bench_type']}",
         )
-        runs = [
-            run
-            for runs in benches.structure[host_val][timestamp_val].values()
-            for run in runs
-        ]
+        runs = [run for run in benches.structure[host_val][timestamp_val]]
         selection = containers[i][2].selectbox(
             "variant", runs, key=f"{prefix}2_{benches.config['bench_type']}"
         )

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -6,16 +6,6 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 ARTIFACTS_DIR = os.path.join(HERE, "..", "..")
 
 
-def fmt_variants(commit, variants):
-    return [f"+{commit}_".join(v.rsplit("_", 1)) for v in variants]
-
-
-def unfmt_variant(variant):
-    prefix, stem = variant.rsplit("_", 1)
-    name, commit = prefix.rsplit("+", 1)
-    return (commit, f"{name}_{stem}")
-
-
 def get_selected_values(n, benches, key_prefix=""):
     containers = [st.columns(3) for i in range(n)]
     selections = []
@@ -32,20 +22,20 @@ def get_selected_values(n, benches, key_prefix=""):
             benches.structure[host_val].keys(),
             key=f"{prefix}1_{benches.config['bench_type']}",
         )
-        commit_variants = benches.structure[host_val][timestamp_val].items()
-        fmtted_variants = [
-            c_v for c, vs in commit_variants for c_v in fmt_variants(c, vs)
+        runs = [
+            run
+            for runs in benches.structure[host_val][timestamp_val].values()
+            for run in runs
         ]
-        variant_val = containers[i][2].selectbox(
-            "variant", fmtted_variants, key=f"{prefix}2_{benches.config['bench_type']}"
+        selection = containers[i][2].selectbox(
+            "variant", runs, key=f"{prefix}2_{benches.config['bench_type']}"
         )
-        selected_commit, selected_variant = unfmt_variant(variant_val)
         selections.append(
             {
-                "host": host_val,
-                "timestamp": timestamp_val,
-                "commit": selected_commit,
-                "variant": selected_variant,
+                "host": selection.host,
+                "timestamp": selection.timestamp,
+                "commit": selection.commit,
+                "variant": selection.variant,
             }
         )
     return selections


### PR DESCRIPTION
This PR does a bunch of preparatory refactoring to simplify the code for getting the selected variant type from the UI. 

The last 3 commits implement functional changes in the UI.

1. Make hostname and date columns much narrower than variant column
2. Remove bench type & stem, show shorter commit hash in dropdown
3. Show a date dropdown instead of timestamp dropdown in the UI when selecting variants

![image](https://user-images.githubusercontent.com/315678/177338165-c81f5b79-c5b0-4d64-879d-f581b23a668f.png)

Closes #60 
