### PR TITLE
Ensure unused pausetime apps are functional too

### DIFF
--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -58,10 +58,15 @@ class BenchStruct:
 
     def get_bench_files(self):
         root_dir = f"{self.config['artifacts_dir']}/{self.config['bench_type']}"
-        pattern = f"{root_dir}/**/*{self.config['bench_stem']}"
-        bench_files = glob.glob(pattern, recursive=True)
-        n = len(root_dir) + 1  # root_dir path + '/'
-        return [path[n:] for path in bench_files]
+        files = []
+        bench_stem = self.config["bench_stem"]
+        stems = [bench_stem] if isinstance(bench_stem, str) else bench_stem
+        for stem in stems:
+            pattern = f"{root_dir}/**/*{stem}"
+            bench_files = glob.glob(pattern, recursive=True)
+            n = len(root_dir) + 1  # root_dir path + '/'
+            files.extend([path[n:] for path in bench_files])
+        return files
 
     def __repr__(self):
         return f"{self.structure}"

--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -24,13 +24,6 @@ class BenchRun:
             self.variant,
         )
 
-    def __repr__(self):
-        prefix, _ = self.variant.rsplit("_", 1)
-        variant = prefix.rstrip(f"+{self.type}")
-        hash_ = self.commit[:7]
-        date, time = self.timestamp.split("_", 1)
-        return f"{variant}+{hash_}+{time}"
-
 
 class BenchStruct:
     config = {}

--- a/app/apps/instrumented_pausetimes_parallel.py
+++ b/app/apps/instrumented_pausetimes_parallel.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from multipledispatch import dispatch
+from apps.utils import get_selected_values, ARTIFACTS_DIR
 
 
 def app():
@@ -62,29 +62,9 @@ def app():
     # ....
     # <host n>
 
-    # This idea is only for sandmark nightly
+    artifacts_dir = os.path.join(ARTIFACTS_DIR, "pausetimes")
 
-    class BenchStruct(benchstruct.BenchStruct):
-        def get_bench_files(self):
-            bench_files = []
-
-            # Loads file metadata
-            for root, dirs, files in os.walk(
-                self.config["artifacts_dir"] + "/" + self.config["bench_type"]
-            ):
-                for file in files:
-                    if file.endswith(self.config["bench_stem"]):
-                        f = root.split("/" + self.config["bench_type"])
-                        bench_files.append((os.path.join(root, file)))
-
-            return bench_files
-
-    current = os.getcwd().split("/")
-    current.pop()
-    artifacts_dir = "/".join(current) + "/sandmark-nightly" + "/pausetimes"
-    # print(artifacts_dir)
-
-    benches = BenchStruct(
+    benches = benchstruct.BenchStruct(
         "parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench"
     )
     benches.add_files(benches.get_bench_files())
@@ -93,108 +73,24 @@ def app():
     st.header("Select variants")
     n = int(st.text_input("Number of variants", "2", key=benches.config["bench_type"]))
 
-    containers = [st.columns(3) for i in range(n)]
+    selected_benches = benchstruct.BenchStruct(
+        "parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench"
+    )
+    for f in get_selected_values(n, benches):
+        selected_benches.add(f.host, f.timestamp, f.commit, f.variant)
+    selected_benches.sort()
 
-    # [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
-    def flatten(lst):
-        return reduce(lambda a, b: a + b, lst)
+    # Expander for showing bench files
+    with st.expander("Show metadata of selected benchmarks"):
+        st.write(selected_benches.display())
 
-    # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
-    def unzip(lst):
-        return list(zip(*lst))
+    selected_files = selected_benches.to_filepath()
 
-    def unzip_dict(d):
-        a = unzip(list(d))
-        # st.write(a)
-        (x, y) = a[0], flatten(a[1])
-        return (x, y)
-
-    @dispatch(str)
     def fmt_variant(file):
         variant = file.split("/")[-1].split("_1")[0]
         commit_id = file.split("/")[-2][:7]
         date = file.split("/")[-3].split("_")[0]
         return str(variant + "_" + date + "_" + commit_id)
-
-    @dispatch(str, str)
-    def fmt_variant(commit, variant):
-        # st.write(variant.split('_'))
-        return (
-            variant.split("_")[0]
-            + "+"
-            + str(commit)
-            + "_"
-            + variant.split("_")[1]
-            + "_"
-            + variant.split("_")[2]
-        )
-
-    def unfmt_variant(variant):
-        commit = variant.split("_")[0].split("+")[-1]
-        variant_root = variant.split("_")[1] + "_" + variant.split("_")[2]
-        # st.write(variant_root)
-        variant_stem = variant.split("_")[0].split("+")
-        variant_stem.pop()
-        variant_stem = reduce(
-            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
-        )
-        new_variant = variant_stem + "_" + variant_root
-        # st.write(new_variant)
-        return (commit, new_variant)
-
-    def get_selected_values(n):
-        lst = []
-        for i in range(n):
-            # create the selectbox in columns
-            host_val = containers[i][0].selectbox(
-                "hostname",
-                benches.structure.keys(),
-                key=str(i) + "0_" + benches.config["bench_type"],
-            )
-            timestamp_val = containers[i][1].selectbox(
-                "timestamp",
-                benches.structure[host_val].keys(),
-                key=str(i) + "1_" + benches.config["bench_type"],
-            )
-            # st.write((benches.structure[host_val][timestamp_val]).items())
-            if (benches.structure[host_val][timestamp_val]).items():
-                commits, variants = unzip_dict(
-                    (benches.structure[host_val][timestamp_val]).items()
-                )
-                # st.write(variants)
-                fmtted_variants = [fmt_variant(c, v) for c, v in zip(commits, variants)]
-                # st.write(fmtted_variants)
-                variant_val = containers[i][2].selectbox(
-                    "variant",
-                    fmtted_variants,
-                    key=str(i) + "2_" + benches.config["bench_type"],
-                )
-                selected_commit, selected_variant = unfmt_variant(variant_val)
-                lst.append(
-                    {
-                        "host": host_val,
-                        "timestamp": timestamp_val,
-                        "commit": selected_commit,
-                        "variant": selected_variant,
-                    }
-                )
-
-        return lst
-
-    selected_benches = BenchStruct(
-        "parallel", artifacts_dir, "_1.pausetimes_multicore.summary.bench"
-    )
-    _ = [
-        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
-        for f in get_selected_values(n)
-    ]
-    selected_benches.sort()
-
-    # Expander for showing bench files
-    with st.expander("Show metadata of selected benchmarks"):
-        st.write(selected_benches.structure)
-
-    selected_files = selected_benches.to_filepath()
 
     def get_dataframe(file):
         # json to dataframe

--- a/app/apps/instrumented_pausetimes_parallel.py
+++ b/app/apps/instrumented_pausetimes_parallel.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values, ARTIFACTS_DIR
+from apps.utils import format_variant, get_selected_values, ARTIFACTS_DIR
 
 
 def app():
@@ -86,12 +86,6 @@ def app():
 
     selected_files = selected_benches.to_filepath()
 
-    def fmt_variant(file):
-        variant = file.split("/")[-1].split("_1")[0]
-        commit_id = file.split("/")[-2][:7]
-        date = file.split("/")[-3].split("_")[0]
-        return str(variant + "_" + date + "_" + commit_id)
-
     def get_dataframe(file):
         # json to dataframe
 
@@ -100,7 +94,7 @@ def app():
             for l in f:
                 data.append(json.loads(l))
             df = pdjson.json_normalize(data)
-        df["variant"] = fmt_variant(file)
+        df["variant"] = format_variant(file, artifacts_dir)
 
         return df
 

--- a/app/apps/instrumented_pausetimes_sequential.py
+++ b/app/apps/instrumented_pausetimes_sequential.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values, ARTIFACTS_DIR
+from apps.utils import format_variant, get_selected_values, ARTIFACTS_DIR
 
 
 def app():
@@ -87,12 +87,6 @@ def app():
 
     selected_files = selected_benches.to_filepath()
 
-    def fmt_variant(file):
-        variant = file.split("/")[-1].split("_1")[0]
-        commit_id = file.split("/")[-2][:7]
-        date = file.split("/")[-3].split("_")[0]
-        return str(variant + "_" + date + "_" + commit_id)
-
     def get_dataframe(file):
         # json to dataframe
 
@@ -101,7 +95,7 @@ def app():
             for l in f:
                 data.append(json.loads(l))
             df = pdjson.json_normalize(data)
-        df["variant"] = fmt_variant(file)
+        df["variant"] = format_variant(file, artifacts_dir)
         return df
 
     def get_dataframes_from_files(files):

--- a/app/apps/instrumented_pausetimes_sequential.py
+++ b/app/apps/instrumented_pausetimes_sequential.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from multipledispatch import dispatch
+from apps.utils import get_selected_values, ARTIFACTS_DIR
 
 
 def app():
@@ -60,29 +60,8 @@ def app():
     # ....
     # <host n>
 
-    # This idea is only for sandmark nightly
-
-    class BenchStruct(benchstruct.BenchStruct):
-        def get_bench_files(self):
-            bench_files = []
-
-            # Loads file metadata
-            for root, dirs, files in os.walk(
-                self.config["artifacts_dir"] + "/" + self.config["bench_type"]
-            ):
-                for file in files:
-                    if file.endswith(self.config["bench_stem"][0]) or file.endswith(
-                        self.config["bench_stem"][1]
-                    ):
-                        f = root.split("/" + self.config["bench_type"])
-                        bench_files.append((os.path.join(root, file)))
-
-            return bench_files
-
-    current = os.getcwd().split("/")
-    current.pop()
-    artifacts_dir = "/".join(current) + "/sandmark-nightly" + "/pausetimes"
-    benches = BenchStruct(
+    artifacts_dir = os.path.join(ARTIFACTS_DIR, "pausetimes")
+    benches = benchstruct.BenchStruct(
         "sequential",
         artifacts_dir,
         ["_1.pausetimes_trunk.summary.bench", "_1.pausetimes_multicore.summary.bench"],
@@ -93,110 +72,26 @@ def app():
     st.header("Select variants")
     n = int(st.text_input("Number of variants", "2", key=benches.config["bench_type"]))
 
-    containers = [st.columns(3) for i in range(n)]
+    selected_benches = benchstruct.BenchStruct(
+        "sequential",
+        artifacts_dir,
+        ["_1.pausetimes_trunk.summary.bench", "_1.pausetimes_multicore.summary.bench"],
+    )
+    for f in get_selected_values(n, benches):
+        selected_benches.add(f.host, f.timestamp, f.commit, f.variant)
+    selected_benches.sort()
 
-    # [[a11, a12 ... a1n], [a21, a22 ... a2n], ... [am1, am2 ... amn]] => [a11]
-    def flatten(lst):
-        return reduce(lambda a, b: a + b, lst)
+    # Expander for showing bench files
+    with st.expander("Show metadata of selected benchmarks"):
+        st.write(selected_benches.display())
 
-    # [(a1, b1), (a2, b2) ... (an, bn)] => ([a1, a2, ... an], [b1, b2, ... bn])
-    def unzip(lst):
-        return list(zip(*lst))
+    selected_files = selected_benches.to_filepath()
 
-    def unzip_dict(d):
-        a = unzip(list(d))
-        # st.write(a)
-        (x, y) = a[0], flatten(a[1])
-        return (x, y)
-
-    @dispatch(str)
     def fmt_variant(file):
         variant = file.split("/")[-1].split("_1")[0]
         commit_id = file.split("/")[-2][:7]
         date = file.split("/")[-3].split("_")[0]
         return str(variant + "_" + date + "_" + commit_id)
-
-    @dispatch(str, str)
-    def fmt_variant(commit, variant):
-        # st.write(variant.split('_'))
-        return (
-            variant.split("_")[0]
-            + "+"
-            + str(commit)
-            + "_"
-            + variant.split("_")[1]
-            + "_"
-            + variant.split("_")[2]
-        )
-
-    def unfmt_variant(variant):
-        commit = variant.split("_")[0].split("+")[-1]
-        variant_root = variant.split("_")[1] + "_" + variant.split("_")[2]
-        # st.write(variant_root)
-        variant_stem = variant.split("_")[0].split("+")
-        variant_stem.pop()
-        variant_stem = reduce(
-            lambda a, b: b if a == "" else a + "+" + b, variant_stem, ""
-        )
-        new_variant = variant_stem + "_" + variant_root
-        # st.write(new_variant)
-        return (commit, new_variant)
-
-    def get_selected_values(n):
-        lst = []
-        for i in range(n):
-            # create the selectbox in columns
-            host_val = containers[i][0].selectbox(
-                "hostname",
-                benches.structure.keys(),
-                key=str(i) + "0_" + benches.config["bench_type"],
-            )
-            timestamp_val = containers[i][1].selectbox(
-                "timestamp",
-                benches.structure[host_val].keys(),
-                key=str(i) + "1_" + benches.config["bench_type"],
-            )
-            # st.write((benches.structure[host_val][timestamp_val]).items())
-            if (benches.structure[host_val][timestamp_val]).items():
-                commits, variants = unzip_dict(
-                    (benches.structure[host_val][timestamp_val]).items()
-                )
-                # st.write(variants)
-                fmtted_variants = [fmt_variant(c, v) for c, v in zip(commits, variants)]
-                # st.write(fmtted_variants)
-                variant_val = containers[i][2].selectbox(
-                    "variant",
-                    fmtted_variants,
-                    key=str(i) + "2_" + benches.config["bench_type"],
-                )
-                selected_commit, selected_variant = unfmt_variant(variant_val)
-                lst.append(
-                    {
-                        "host": host_val,
-                        "timestamp": timestamp_val,
-                        "commit": selected_commit,
-                        "variant": selected_variant,
-                    }
-                )
-
-        return lst
-
-    selected_benches = BenchStruct(
-        "sequential",
-        artifacts_dir,
-        ["_1.pausetimes_trunk.summary.bench", "_1.pausetimes_multicore.summary.bench"],
-    )
-    _ = [
-        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
-        for f in get_selected_values(n)
-    ]
-    selected_benches.sort()
-
-    # Expander for showing bench files
-    with st.expander("Show metadata of selected benchmarks"):
-        st.write(selected_benches.structure)
-
-    selected_files = selected_benches.to_filepath()
 
     def get_dataframe(file):
         # json to dataframe
@@ -207,7 +102,6 @@ def app():
                 data.append(json.loads(l))
             df = pdjson.json_normalize(data)
         df["variant"] = fmt_variant(file)
-
         return df
 
     def get_dataframes_from_files(files):

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -50,7 +50,7 @@ def app():
                 if "name" in temp:
                     data.append(temp)
             df = pd.json_normalize(data)
-            df["variant"] = format_variant(file, benches.config["bench_type"])
+            df["variant"] = format_variant(file)
         return df
 
     def get_dataframes_from_files(files):

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values, ARTIFACTS_DIR
+from apps.utils import get_selected_values, format_variant, ARTIFACTS_DIR
 
 
 def app():
@@ -43,7 +43,6 @@ def app():
 
     def get_dataframe(file):
         # json to dataframe
-
         with open(file) as f:
             data = []
             for l in f:
@@ -51,12 +50,7 @@ def app():
                 if "name" in temp:
                     data.append(temp)
             df = pd.json_normalize(data)
-            value = file.split("/" + benches.config["bench_type"] + "/")[1]
-            date = value.split("/")[1].split("_")[0]
-            commit_id = value.split("/")[2][:7]
-            variant = value.split("/")[3].split("_")[0]
-            df["variant"] = variant + "_" + date + "_" + commit_id
-
+            df["variant"] = format_variant(file, benches.config["bench_type"])
         return df
 
     def get_dataframes_from_files(files):

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -32,7 +32,7 @@ def app():
         "parallel", ARTIFACTS_DIR, "_1.orunchrt.summary.bench"
     )
     for f in get_selected_values(n, benches):
-        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
+        selected_benches.add(f.host, f.timestamp, f.commit, f.variant)
     selected_benches.sort()
 
     # Expander for showing bench files

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -108,7 +108,7 @@ def app():
                 if "name" in temp:
                     data.append(temp)
             df = pd.json_normalize(data)
-            df["variant"] = format_variant(file, benches.config["bench_type"])
+            df["variant"] = format_variant(file)
         return df
 
     def get_dataframes_from_files(files):

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -70,7 +70,7 @@ def app():
         "sequential", ARTIFACTS_DIR, "_1.orun.summary.bench"
     )
     for f in get_selected_values(n, benches):
-        selected_benches.add(f["host"], f["timestamp"], f["commit"], f["variant"])
+        selected_benches.add(f.host, f.timestamp, f.commit, f.variant)
 
     # Expander for showing bench files
     st.subheader("Benchmarks Selected")
@@ -131,10 +131,10 @@ def app():
         return graph
 
     def fmt_baseline(record):
-        date = record["timestamp"].split("_")[0]
-        commit = record["commit"][:7]
-        variant = record["variant"].split("_")[0]
-        s = str(variant) + "_" + date + "_" + commit
+        date = record.timestamp.split("_")[0]
+        commit = record.commit[:7]
+        variant = record.variant.split("_")[0]
+        s = variant + "_" + date + "_" + commit
         return s
 
     def create_column(df, variant, metric):

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pandas.io.json as pdjson
 import seaborn as sns
 from apps import benchstruct
-from apps.utils import get_selected_values, ARTIFACTS_DIR
+from apps.utils import get_selected_values, format_variant, ARTIFACTS_DIR
 
 
 def app():
@@ -108,11 +108,7 @@ def app():
                 if "name" in temp:
                     data.append(temp)
             df = pd.json_normalize(data)
-            value = file.split("/" + benches.config["bench_type"] + "/")[1]
-            date = value.split("/")[1].split("_")[0]
-            commit_id = value.split("/")[2][:7]
-            variant = value.split("/")[3].split("_")[0]
-            df["variant"] = variant + "_" + date + "_" + commit_id
+            df["variant"] = format_variant(file, benches.config["bench_type"])
         return df
 
     def get_dataframes_from_files(files):
@@ -133,7 +129,7 @@ def app():
     def fmt_baseline(record):
         date = record.timestamp.split("_")[0]
         commit = record.commit[:7]
-        variant = record.variant.split("_")[0]
+        variant = record.variant.rsplit("_", 1)[0]
         s = variant + "_" + date + "_" + commit
         return s
 

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -14,6 +14,14 @@ def format_bench_run(run):
     return f"{variant}+{hash_}+{time}"
 
 
+def format_variant(path, bench_type):
+    value = path.split("/" + bench_type + "/")[1]
+    date = value.split("/")[1].split("_")[0]
+    commit_id = value.split("/")[2][:7]
+    variant = value.split("/")[3].split("_", 1)[0]
+    return variant + "_" + date + "_" + commit_id
+
+
 def get_selected_values(n, benches, key_prefix=""):
     containers = [st.columns([1, 1, 4]) for i in range(n)]
     selections = []

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -44,6 +44,7 @@ def get_selected_values(n, benches, key_prefix=""):
             runs,
             key=f"{prefix}2_{benches.config['bench_type']}",
             format_func=format_bench_run,
+            disabled=len(runs) <= 1,
         )
         selections.append(selection)
     return selections

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -37,12 +37,5 @@ def get_selected_values(n, benches, key_prefix=""):
             key=f"{prefix}2_{benches.config['bench_type']}",
             format_func=format_bench_run,
         )
-        selections.append(
-            {
-                "host": selection.host,
-                "timestamp": selection.timestamp,
-                "commit": selection.commit,
-                "variant": selection.variant,
-            }
-        )
+        selections.append(selection)
     return selections

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -14,12 +14,12 @@ def format_bench_run(run):
     return f"{variant}+{hash_}+{time}"
 
 
-def format_variant(path, bench_type):
-    value = path.split("/" + bench_type + "/")[1]
-    date = value.split("/")[1].split("_")[0]
-    commit_id = value.split("/")[2][:7]
-    variant = value.split("/")[3].split("_", 1)[0]
-    return variant + "_" + date + "_" + commit_id
+def format_variant(path, artifacts_dir=ARTIFACTS_DIR):
+    relpath = os.path.relpath(path, artifacts_dir)
+    _, _, timestamp, commit_id, variant = relpath.split("/")
+    date, _ = timestamp.split("_")
+    variant = variant.split("_", 1)[0]
+    return f"{variant}_{date}_{commit_id[:7]}"
 
 
 def get_selected_values(n, benches, key_prefix=""):

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -6,6 +6,14 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 ARTIFACTS_DIR = os.path.join(HERE, "..", "..")
 
 
+def format_bench_run(run):
+    prefix, _ = run.variant.rsplit("_", 1)
+    variant = prefix.rstrip(f"+{run.type}")
+    hash_ = run.commit[:7]
+    date, time = run.timestamp.split("_", 1)
+    return f"{variant}+{hash_}+{time}"
+
+
 def get_selected_values(n, benches, key_prefix=""):
     containers = [st.columns([1, 1, 4]) for i in range(n)]
     selections = []
@@ -24,7 +32,10 @@ def get_selected_values(n, benches, key_prefix=""):
         )
         runs = [run for run in benches.structure[host_val][date_val]]
         selection = containers[i][2].selectbox(
-            "variant", runs, key=f"{prefix}2_{benches.config['bench_type']}"
+            "variant",
+            runs,
+            key=f"{prefix}2_{benches.config['bench_type']}",
+            format_func=format_bench_run,
         )
         selections.append(
             {


### PR DESCRIPTION
#63 changed some of the common utility code like BenchStruct, which would break the pausetimes sequential and parallel apps. This PR makes sure that the new changes are compatible with both these apps, even if they are unused in the UI. 