### PR TITLE
Automatically copy results for successful builds and notify on Slack

### DIFF
--- a/.github/workflows/copy-successful-builds.yml
+++ b/.github/workflows/copy-successful-builds.yml
@@ -21,4 +21,6 @@ jobs:
         #   ref: 'main'
 
       - name: Run script to copy successful builds
+        env:
+          SLACK_API_URL: ${{ secrets.SLACK_API_URL }}
         run: ./scripts/copy-successful-builds.sh

--- a/.github/workflows/copy-successful-builds.yml
+++ b/.github/workflows/copy-successful-builds.yml
@@ -1,0 +1,24 @@
+# Workflow to copy successful builds to main branch
+---
+on:
+  # Triggers the workflow on push to testing branch, containing bench files
+  push:
+    branches:
+      - 'testing'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  copy_successful_builds:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        # FIXME: Can use this when the script is merged to main
+        # with:
+        #   ref: 'main'
+
+      - name: Run script to copy successful builds
+        run: ./scripts/copy-successful-builds.sh

--- a/scripts/copy-successful-builds.sh
+++ b/scripts/copy-successful-builds.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+GIT_REMOTE="${1:-origin}"
+
+SUCCESSFUL_BUILDS=0
+
+# Fetch testing branch to be able to see what changed on it, etc.
+# NOTE: This may not be necessary when running on testing branch in CI, but
+# making sure the name origin/testing can be referenced.
+git fetch "${GIT_REMOTE}" testing
+# Fetch main branch to be able to switch to it, and copy stuff to it.
+git fetch "${GIT_REMOTE}" main
+
+LAST_COMMIT_FILES=$(git diff-tree --no-commit-id --name-only -r "${GIT_REMOTE}/testing" --diff-filter=d)
+
+CHANGED_DIRS=$(for each in ${LAST_COMMIT_FILES}; do
+                   dirname "${each}"
+               done | sort -u)
+
+# Ensure the main branch is checked out
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "${CURRENT_BRANCH}" != "main" ]; then
+    git checkout -B main "${GIT_REMOTE}/main"
+fi
+
+for dir in ${CHANGED_DIRS}; do
+    if echo "${LAST_COMMIT_FILES}" | grep -qoP "${dir}/.*.summary.bench"; then
+        git checkout "${GIT_REMOTE}/testing" "${dir}"
+        SUCCESSFUL_BUILDS=1
+        echo "Copied ${dir}"
+    else
+        echo "Failed build in ${dir}"
+    fi
+done
+
+TESTING_COMMIT=$(git rev-parse "${GIT_REMOTE}/testing")
+
+if [ ${SUCCESSFUL_BUILDS} -ge 1 ]; then
+    # Try to commit only if files have been staged. No files are staged, if the
+    # files are already on main branch.
+    git diff --name-only --cached | grep -qoP "." && \
+        git commit -m "Automated commit for successful benchmarks in ${TESTING_COMMIT}"
+    git push "${GIT_REMOTE}" main
+fi
+
+git checkout "${CURRENT_BRANCH}"

--- a/scripts/copy-successful-builds.sh
+++ b/scripts/copy-successful-builds.sh
@@ -43,6 +43,9 @@ if [ ${SUCCESSFUL_BUILDS} -ge 1 ]; then
     git diff --name-only --cached | grep -qoP "." && \
         git commit -m "Automated commit for successful benchmarks in ${TESTING_COMMIT}"
     git push "${GIT_REMOTE}" main
+    MAIN_COMMIT=$(git rev-parse HEAD)
 fi
 
 git checkout "${CURRENT_BRANCH}"
+
+"$(dirname "${0}")/slack-notify-build-status.sh" "${CHANGED_DIRS}" "${TESTING_COMMIT}" "${MAIN_COMMIT:-}"

--- a/scripts/slack-notify-build-status.sh
+++ b/scripts/slack-notify-build-status.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+
+function commit_url {
+    echo "https://github.com/ocaml-bench/sandmark-nightly/commit/${1}"
+}
+
+CHANGED_DIRS=$1
+TESTING_COMMIT=$2
+MAIN_COMMIT=$3
+
+for dir in ${CHANGED_DIRS}; do
+    BENCH_FILE=$(find "${dir}" -name "*.summary.bench" -type f | head -n 1)
+    if [ -n "${BENCH_FILE}" ]; then
+        PASSED_BUILDS="${PASSED_BUILDS:-}\n- $(basename "${BENCH_FILE}")"
+    else
+        LOG_FILE=$(find "${dir}" -name "*.log" -type f | head -n 1)
+        FAILED_BUILDS="${FAILED_BUILDS:-}\n- $(basename "${LOG_FILE}")"
+    fi
+done
+
+if [ -n "${PASSED_BUILDS:-}" ]; then
+    PASSED_BLOCK="{
+                        \"type\": \"header\",
+                        \"text\": {
+                                \"type\": \"plain_text\",
+                                \"text\": \"Successful builds\"
+                        }
+                },
+                {
+                        \"type\": \"section\",
+                        \"text\": {
+                                \"type\": \"mrkdwn\",
+                                \"text\": \"${PASSED_BUILDS}\"
+                        }
+                },
+                {
+                        \"type\": \"section\",
+                        \"text\": {
+                                \"type\": \"mrkdwn\",
+                                \"text\": \"Click here to see the <$(commit_url ${MAIN_COMMIT})|successful builds commit> on main\"
+                        }
+                },"
+fi
+
+if [ -n "${FAILED_BUILDS:-}" ]; then
+    FAILED_BLOCK="{
+                        \"type\": \"header\",
+                        \"text\": {
+                                \"type\": \"plain_text\",
+                                \"text\": \"Failed builds\"
+                        }
+                },
+                {
+                        \"type\": \"section\",
+                        \"text\": {
+                                \"type\": \"mrkdwn\",
+                                \"text\": \"${FAILED_BUILDS}\"
+                        }
+                },
+                {
+                        \"type\": \"section\",
+                        \"text\": {
+                                \"type\": \"mrkdwn\",
+                                \"text\": \"Click here to see the <$(commit_url ${TESTING_COMMIT})|commit> on testing\"
+                        }
+                }"
+fi
+
+
+if [[ -n ${PASSED_BLOCK:-} || -n ${FAILED_BLOCK:-} ]]; then
+    SLACK_TEXT="{
+            \"blocks\": [
+                        ${PASSED_BLOCK:-}
+                        ${FAILED_BLOCK:-}
+            ]
+    }"
+    set +x  # Don't print SLACK_API_URL in the logs...
+    curl "${SLACK_API_URL}" --data-raw "${SLACK_TEXT}" -H "Content-type: application/json"
+    set -x
+fi


### PR DESCRIPTION
The PR adds a script to copy successful builds from testing to main branch, and sets up a GitHub hook that runs when there are changes to the testing branch. This closes #65 

The PR also sends a Slack notification with information about successful and failed builds. This closes #42 

To get the GitHub action to run correctly, the sandmark-nightly repo needs to have a secret called `SLACK_API_URL` added. (I don't have the right permissions to do that). 

Examples of successful runs of the GitHub action can be found [here](https://github.com/punchagan/sandmark-nightly/actions).  This PR itself doesn't trigger any GitHub actions because the action is restricted to trigger only on the `testing` branch.