### PR TITLE
Allow filtering variants to select by hostname or variant name 

### DIFF
--- a/app/apps/benchstruct.py
+++ b/app/apps/benchstruct.py
@@ -30,6 +30,7 @@ class BenchStruct:
 
     def __init__(self, bench_type, artifacts_dir, bench_stem):
         self.structure = nested_dict(2, list)
+        self.structure_by_variant = nested_dict(2, list)
         self.config["bench_type"] = bench_type
         self.config["artifacts_dir"] = artifacts_dir
         self.config["bench_stem"] = bench_stem
@@ -44,6 +45,8 @@ class BenchStruct:
         )
         date, _ = timestamp.split("_", 1)
         self.structure[host][date].append(run)
+        v = variant.rsplit("_", 1)[0]
+        self.structure_by_variant[v][date].append(run)
 
     def add_files(self, files):
         for relative_path in files:

--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -31,7 +31,8 @@ def app():
     selected_benches = benchstruct.BenchStruct(
         "parallel", ARTIFACTS_DIR, "_1.orunchrt.summary.bench"
     )
-    for f in get_selected_values(n, benches):
+    by = st.radio("Find Benchmark By", options=["variant", "hostname"], horizontal=True)
+    for f in get_selected_values(n, benches, by=by):
         selected_benches.add(f.host, f.timestamp, f.commit, f.variant)
     selected_benches.sort()
 

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -69,7 +69,8 @@ def app():
     selected_benches = benchstruct.BenchStruct(
         "sequential", ARTIFACTS_DIR, "_1.orun.summary.bench"
     )
-    for f in get_selected_values(n, benches):
+    by = st.radio("Find Benchmark By", options=["variant", "hostname"], horizontal=True)
+    for f in get_selected_values(n, benches, by=by):
         selected_benches.add(f.host, f.timestamp, f.commit, f.variant)
 
     # Expander for showing bench files

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -22,27 +22,30 @@ def format_variant(path, artifacts_dir=ARTIFACTS_DIR):
 
 
 def get_selected_values(n, benches, key_prefix=""):
-    containers = [st.columns([1, 1, 4]) for i in range(n)]
+    structure = benches.structure
+    format_func = format_bench_run
+    type_ = benches.config["bench_type"]
     selections = []
-    for i in range(n):
+    labels = ["hostname", "date", "variant"]
+    containers = [st.columns([1, 1, 4]) for i in range(n)]
+    for row in range(n):
         # create the selectbox in columns
-        prefix = key_prefix or str(i)
-        host_val = containers[i][0].selectbox(
-            "hostname",
-            benches.structure.keys(),
-            key=f"{prefix}0_{benches.config['bench_type']}",
+        prefix = key_prefix or str(row)
+        col = 0
+        first_val = containers[row][col].selectbox(
+            labels[col], sorted(structure.keys()), key=f"{prefix}{col}_{type_}"
         )
-        date_val = containers[i][1].selectbox(
-            "date",
-            benches.structure[host_val].keys(),
-            key=f"{prefix}1_{benches.config['bench_type']}",
+        col = 1
+        date_val = containers[row][col].selectbox(
+            labels[col], structure[first_val].keys(), key=f"{prefix}{col}_{type_}"
         )
-        runs = [run for run in benches.structure[host_val][date_val]]
-        selection = containers[i][2].selectbox(
-            "variant",
+        col = 2
+        runs = [run for run in structure[first_val][date_val]]
+        selection = containers[row][col].selectbox(
+            labels[col],
             runs,
-            key=f"{prefix}2_{benches.config['bench_type']}",
-            format_func=format_bench_run,
+            key=f"{prefix}{col}_{type_}",
+            format_func=format_func,
             disabled=len(runs) <= 1,
         )
         selections.append(selection)

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -6,11 +6,18 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 ARTIFACTS_DIR = os.path.join(HERE, "..", "..")
 
 
-def format_bench_run(run):
+def format_bench_run_by_host(run):
     prefix, _ = run.variant.rsplit("_", 1)
     variant = prefix.rstrip(f"+{run.type}")
     hash_ = run.commit[:7]
     return f"{variant}+{hash_}+{run.timestamp}"
+
+
+def format_bench_run_by_variant(run):
+    prefix, _ = run.variant.rsplit("_", 1)
+    variant = prefix.rstrip(f"+{run.type}")
+    hash_ = run.commit[:7]
+    return f"{run.host}+{hash_}+{run.timestamp}"
 
 
 def format_variant(path, artifacts_dir=ARTIFACTS_DIR):
@@ -21,22 +28,31 @@ def format_variant(path, artifacts_dir=ARTIFACTS_DIR):
     return f"{variant}_{date}_{commit_id[:7]}"
 
 
-def get_selected_values(n, benches, key_prefix=""):
-    structure = benches.structure
-    format_func = format_bench_run
+def get_selected_values(n, benches, key_prefix="", by="host"):
+    if by == "variant":
+        labels = ["variant", "date", "host"]
+        structure = benches.structure_by_variant
+        format_func = format_bench_run_by_variant
+        column_widths = [3, 1, 2]
+    else:
+        labels = ["hostname", "date", "variant"]
+        structure = benches.structure
+        format_func = format_bench_run_by_host
+        column_widths = [1, 1, 4]
     type_ = benches.config["bench_type"]
     selections = []
-    labels = ["hostname", "date", "variant"]
-    containers = [st.columns([1, 1, 4]) for i in range(n)]
+    containers = [st.columns(column_widths) for i in range(n)]
     for row in range(n):
         # create the selectbox in columns
         prefix = key_prefix or str(row)
         col = 0
         first_val = containers[row][col].selectbox(
-            labels[col], sorted(structure.keys()), key=f"{prefix}{col}_{type_}"
+            labels[col],
+            sorted(structure.keys(), reverse=True),
+            key=f"{prefix}{col}_{type_}",
         )
         col = 1
-        dates = structure[first_val].keys()
+        dates = sorted(structure[first_val].keys(), reverse=True)
         date_val = containers[row][col].selectbox(
             labels[col], dates, key=f"{prefix}{col}_{type_}", disabled=len(dates) <= 1
         )

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -36,8 +36,9 @@ def get_selected_values(n, benches, key_prefix=""):
             labels[col], sorted(structure.keys()), key=f"{prefix}{col}_{type_}"
         )
         col = 1
+        dates = structure[first_val].keys()
         date_val = containers[row][col].selectbox(
-            labels[col], structure[first_val].keys(), key=f"{prefix}{col}_{type_}"
+            labels[col], dates, key=f"{prefix}{col}_{type_}", disabled=len(dates) <= 1
         )
         col = 2
         runs = [run for run in structure[first_val][date_val]]

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -10,8 +10,7 @@ def format_bench_run(run):
     prefix, _ = run.variant.rsplit("_", 1)
     variant = prefix.rstrip(f"+{run.type}")
     hash_ = run.commit[:7]
-    date, time = run.timestamp.split("_", 1)
-    return f"{variant}+{hash_}+{time}"
+    return f"{variant}+{hash_}+{run.timestamp}"
 
 
 def format_variant(path, artifacts_dir=ARTIFACTS_DIR):


### PR DESCRIPTION
As an initial experiment to fix #67 I've added a radio button to allow searching for a benchmark by variant or hostname.  I've used date as the second level of filter in both the cases.

@shakthimaan Let me know if this is good as a first version, or if we should do something different here. 

## Filtering for a benchmark by variant name (new UI)
![image](https://user-images.githubusercontent.com/315678/180375733-905ed784-c28c-40dc-87ac-e67507e55883.png)

## Filtering by hostname (old UI)
![image](https://user-images.githubusercontent.com/315678/180375773-5e731300-53a6-4cd5-b048-7b71149b96d8.png)
