### PR TITLE
Fix accidentally deleted push in successful results copy script

### DIFF
--- a/scripts/copy-successful-builds.sh
+++ b/scripts/copy-successful-builds.sh
@@ -51,6 +51,7 @@ if [ ${SUCCESSFUL_BUILDS} -ge 1 ]; then
     git config user.name "Sandmark Nightly Bot"
     git diff --name-only --cached | grep -qoP "." && \
         git commit -m "Auto-copy successful results from ${TESTING_COMMIT} (${HOSTNAME})"
+    git push "${GIT_REMOTE}" main
     MAIN_COMMIT=$(git rev-parse HEAD)
 fi
 


### PR DESCRIPTION
76cfc5d7a590772a7967ddf27f2cca692cbbbb7c accidentally deleted the `git push`
command, which broke the copying of successful builds from testing to main.

These changes need to be merged into `testing` once they are merged on `main`. 