### PR TITLE
Fix error in parallel app for missing sequential benchmark

### DIFF
--- a/app/apps/parallel_benchmarks.py
+++ b/app/apps/parallel_benchmarks.py
@@ -86,8 +86,9 @@ def app():
         for g in mdf.groupby("name"):
             (n, d) = g
             n = n.replace("_multicore", "")
-            d["n" + topic] = 1 / d[topic].div(fastest_sequential[n], axis=0)
-            d["b" + topic] = int(fastest_sequential[n])
+            if n in fastest_sequential:
+                d["n" + topic] = 1 / d[topic].div(fastest_sequential[n], axis=0)
+                d["b" + topic] = int(fastest_sequential[n])
             frames.append(d)
         return pd.concat(frames, ignore_index=True)
 


### PR DESCRIPTION
When the sequential run for a benchmark cannot be found, the parallel benchmark
app crashes.  Currently, the fannkuchredux sequential run seems to be
failing.  This commit fixes the crash in the streamlit app.  The problem with
the benchmark itself needs to be fixed, separately, though.

Closes #83