### PR TITLE
Fix Perfstat app when selected variants have different benchmarks

### DIFF
--- a/app/apps/perfstat.py
+++ b/app/apps/perfstat.py
@@ -63,29 +63,24 @@ def extract(field, line, row):
 
 def normalise(df, variant, topic, additionalTopics=[]):
     df = add_display_name(df, variant, topic)
-    df = df.sort_values(["name", "variant"])
-    grouped = df.filter(
-        items=["name", topic, "variant", "display_name"] + additionalTopics
-    ).groupby("variant")
-    ndata_frames = []
-    for group in grouped:
-        (v, data) = group
-        if v != variant:
-            data["b" + topic] = grouped.get_group(variant)[topic].values
-            data[["n" + topic]] = data[[topic]].div(
-                grouped.get_group(variant)[topic].values, axis=0
-            )
-            for t in additionalTopics:
-                data[[t]] = grouped.get_group(variant)[t].values
-            ndata_frames.append(data)
-    if ndata_frames:
-        df = pd.concat(ndata_frames)
-        return df
-    else:
+    items = ["name", topic, "variant", "display_name"] + additionalTopics
+    df_filtered = df.filter(items=items)
+    try:
+        df_pivot = df_filtered.reset_index().pivot(
+            index="name", columns="variant", values=[topic]
+        )
+    except ValueError:
         st.warning(
             "Variants selected are the same, please select different variants to generate a normalized graph"
         )
         return pd.DataFrame()
+    baseline_column = (topic, variant)
+    select_columns = [c for c in df_pivot.columns if c != baseline_column]
+    normalised = df_pivot.div(df_pivot[baseline_column], axis=0)[select_columns]
+    normalised = normalised.melt(
+        col_level=1, ignore_index=False, value_name="n" + topic
+    ).reset_index()
+    return pd.merge(normalised, df_filtered, on=["name", "variant"])
 
 
 def plot_normalised(df, variant, topic):

--- a/app/apps/perfstat.py
+++ b/app/apps/perfstat.py
@@ -11,6 +11,7 @@ from apps.utils import (
     format_variant,
     fmt_baseline,
     ARTIFACTS_DIR,
+    normalise,
 )
 
 
@@ -59,28 +60,6 @@ def extract(field, line, row):
     m = re.search("\s*(.*)\s*" + field, line)
     if m:
         row[field] = int(m.group(1).replace(",", "").replace(" ", ""))
-
-
-def normalise(df, variant, topic, additionalTopics=[]):
-    df = add_display_name(df, variant, topic)
-    items = ["name", topic, "variant", "display_name"] + additionalTopics
-    df_filtered = df.filter(items=items)
-    try:
-        df_pivot = df_filtered.reset_index().pivot(
-            index="name", columns="variant", values=[topic]
-        )
-    except ValueError:
-        st.warning(
-            "Variants selected are the same, please select different variants to generate a normalized graph"
-        )
-        return pd.DataFrame()
-    baseline_column = (topic, variant)
-    select_columns = [c for c in df_pivot.columns if c != baseline_column]
-    normalised = df_pivot.div(df_pivot[baseline_column], axis=0)[select_columns]
-    normalised = normalised.melt(
-        col_level=1, ignore_index=False, value_name="n" + topic
-    ).reset_index()
-    return pd.merge(normalised, df_filtered, on=["name", "variant"])
 
 
 def plot_normalised(df, variant, topic):

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -141,7 +141,6 @@ def app():
             return pd.DataFrame()
 
         else:
-            st.write(normalization_state)
             df = add_display_name(df, baseline, topic)
             items = ["name", topic, "variant", "display_name"] + additionalTopics
             df_filtered = df.filter(items=items)

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -208,7 +208,8 @@ def app():
         st.write(ndf)
     with st.expander("Graph", expanded=True):
         g = plot_normalised(baseline, ndf, "ntime_secs")
-        st.pyplot(g)
+        if g is not None:
+            st.pyplot(g)
 
     st.header("Top heap words")
     with st.expander("Data"):
@@ -221,7 +222,8 @@ def app():
         st.write(ndf)
     with st.expander("Graph", expanded=True):
         g = plot_normalised(baseline, ndf, "ngc.top_heap_words")
-        st.pyplot(g)
+        if g is not None:
+            st.pyplot(g)
 
     st.header("Max RSS (KB)")
     with st.expander("Data"):
@@ -234,7 +236,8 @@ def app():
         st.write(ndf)
     with st.expander("Graph", expanded=True):
         g = plot_normalised(baseline, ndf, "nmaxrss_kB")
-        st.pyplot(g)
+        if g is not None:
+            st.pyplot(g)
 
     st.header("Major Collections")
     with st.expander("Data"):
@@ -247,7 +250,8 @@ def app():
         st.write(ndf)
     with st.expander("Graph", expanded=True):
         g = plot_normalised(baseline, ndf, "ngc.major_collections")
-        st.pyplot(g)
+        if g is not None:
+            st.pyplot(g)
 
     st.header("Minor Collections")
     with st.expander("Data"):
@@ -260,4 +264,5 @@ def app():
         st.write(ndf)
     with st.expander("Graph", expanded=True):
         g = plot_normalised(baseline, ndf, "ngc.minor_collections")
-        st.pyplot(g)
+        if g is not None:
+            st.pyplot(g)

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -200,9 +200,8 @@ def app():
         st.write(df)
     with st.expander("Graph", expanded=True):
         st.pyplot(plot(df.copy(), "time_secs"))
-
-    ndf = normalise(df.copy(), baseline, "time_secs", normalization_state)
     st.header("Normalized Time")
+    ndf = normalise(df.copy(), baseline, "time_secs", normalization_state)
     with st.expander("Data"):
         st.write(ndf)
     with st.expander("Graph", expanded=True):
@@ -215,8 +214,8 @@ def app():
         st.write(df)
     with st.expander("Graph", expanded=True):
         st.pyplot(plot(df.copy(), "gc.top_heap_words"))
-    ndf = normalise(df.copy(), baseline, "gc.top_heap_words", normalization_state)
     st.header("Normalized top heap words")
+    ndf = normalise(df.copy(), baseline, "gc.top_heap_words", normalization_state)
     with st.expander("Data"):
         st.write(ndf)
     with st.expander("Graph", expanded=True):
@@ -229,8 +228,8 @@ def app():
         st.write(df)
     with st.expander("Graph", expanded=True):
         st.pyplot(plot(df.copy(), "maxrss_kB"))
-    ndf = normalise(df.copy(), baseline, "maxrss_kB", normalization_state)
     st.header("Normalized Max RSS (KB)")
+    ndf = normalise(df.copy(), baseline, "maxrss_kB", normalization_state)
     with st.expander("Data"):
         st.write(ndf)
     with st.expander("Graph", expanded=True):
@@ -243,8 +242,8 @@ def app():
         st.write(df)
     with st.expander("Graph", expanded=True):
         st.pyplot(plot(df.copy(), "gc.major_collections"))
-    ndf = normalise(df.copy(), baseline, "gc.major_collections", normalization_state)
     st.header("Normalized major collections")
+    ndf = normalise(df.copy(), baseline, "gc.major_collections", normalization_state)
     with st.expander("Data"):
         st.write(ndf)
     with st.expander("Graph", expanded=True):
@@ -257,8 +256,8 @@ def app():
         st.write(df)
     with st.expander("Graph", expanded=True):
         st.pyplot(plot(df.copy(), "gc.minor_collections"))
-    ndf = normalise(df.copy(), baseline, "gc.minor_collections", normalization_state)
     st.header("Normalized minor collections")
+    ndf = normalise(df.copy(), baseline, "gc.minor_collections", normalization_state)
     with st.expander("Data"):
         st.write(ndf)
     with st.expander("Graph", expanded=True):

--- a/app/apps/sequential_benchmarks.py
+++ b/app/apps/sequential_benchmarks.py
@@ -19,6 +19,7 @@ from apps.utils import (
     format_variant,
     fmt_baseline,
     ARTIFACTS_DIR,
+    normalise,
 )
 
 
@@ -127,27 +128,6 @@ def app():
         )
         graph.set_xticklabels(rotation=90)
         return graph
-
-    def normalise(df, baseline, topic, additionalTopics=[]):
-        df = add_display_name(df, baseline, topic)
-        items = ["name", topic, "variant", "display_name"] + additionalTopics
-        df_filtered = df.filter(items=items)
-        try:
-            df_pivot = df_filtered.reset_index().pivot(
-                index="name", columns="variant", values=[topic]
-            )
-        except ValueError:
-            st.warning(
-                "Variants selected are the same, please select different variants to generate a normalized graph"
-            )
-            return pd.DataFrame()
-        baseline_column = (topic, baseline)
-        select_columns = [c for c in df_pivot.columns if c != baseline_column]
-        normalised = df_pivot.div(df_pivot[baseline_column], axis=0)[select_columns]
-        normalised = normalised.melt(
-            col_level=1, ignore_index=False, value_name="n" + topic
-        ).reset_index()
-        return pd.merge(normalised, df_filtered, on=["name", "variant"])
 
     def plot_normalised(baseline, df, topic):
         xlabel = "Benchmarks (baseline = " + baseline + ")"

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -82,12 +82,12 @@ def get_selected_values(n, benches, key_prefix="", by="host"):
     return selections
 
 
+def get_display_name(row, metric):
+    name = row["name"]
+    value = row[metric]
+    return f"{name} ({value:.2f})"
+
+
 def add_display_name(df, variant, metric):
-    name_metric = {
-        n: t for (t, v, n) in zip(df[metric], df["variant"], df["name"]) if v == variant
-    }
-    disp_name = [
-        name + " (" + str(round(name_metric[name], 2)) + ")" for name in df["name"]
-    ]
-    df["display_name"] = pd.Series(disp_name, index=df.index)
+    df["display_name"] = df.apply(get_display_name, axis=1, metric=metric)
     return df

--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -91,3 +91,25 @@ def get_display_name(row, metric):
 def add_display_name(df, variant, metric):
     df["display_name"] = df.apply(get_display_name, axis=1, metric=metric)
     return df
+
+
+def normalise(df, baseline, topic, additionalTopics=[]):
+    df = add_display_name(df, baseline, topic)
+    items = ["name", topic, "variant", "display_name"] + additionalTopics
+    df_filtered = df.filter(items=items)
+    try:
+        df_pivot = df_filtered.reset_index().pivot(
+            index="name", columns="variant", values=[topic]
+        )
+    except ValueError:
+        st.warning(
+            "Variants selected are the same, please select different variants to generate a normalized graph"
+        )
+        return pd.DataFrame()
+    baseline_column = (topic, baseline)
+    select_columns = [c for c in df_pivot.columns if c != baseline_column]
+    normalised = df_pivot.div(df_pivot[baseline_column], axis=0)[select_columns]
+    normalised = normalised.melt(
+        col_level=1, ignore_index=False, value_name="n" + topic
+    ).reset_index()
+    return pd.merge(normalised, df_filtered, on=["name", "variant"])


### PR DESCRIPTION
This commit simplifies and fixes the `add_display_name` function to work correctly, when the different variants selected have a different set of benchmarks.

It also fixes another issue that is similar to the one fixed by https://github.com/ocaml-bench/sandmark/pull/351where a difference in the list of benchmarks in the two selected variants causes the `normalise` function to crash.