### PR TITLE
Gracefully handle baseline data being empty

### DIFF
--- a/app/apps/utils.py
+++ b/app/apps/utils.py
@@ -108,7 +108,13 @@ def normalise(df, baseline, topic, additionalTopics=[]):
         return pd.DataFrame()
     baseline_column = (topic, baseline)
     select_columns = [c for c in df_pivot.columns if c != baseline_column]
-    normalised = df_pivot.div(df_pivot[baseline_column], axis=0)[select_columns]
+    try:
+        normalised = df_pivot.div(df_pivot[baseline_column], axis=0)[select_columns]
+    except KeyError:
+        st.error(
+            "Baseline data is empty, please select a different baseline to generate a normalized graph"
+        )
+        return pd.DataFrame()
     normalised = normalised.melt(
         col_level=1, ignore_index=False, value_name="n" + topic
     ).reset_index()


### PR DESCRIPTION
This seems to happen sometimes with the Perfstat data and the UI crashes due to this. This commit displays an error message instead of the traceback.