### PR TITLE
Run daily UI tests against production as a cron job

### DIFF
--- a/.github/workflows/production-user-tests.yml
+++ b/.github/workflows/production-user-tests.yml
@@ -1,0 +1,30 @@
+# Workflow to Run UI Tests against production
+---
+name: Run UI Tests against production
+on:
+  schedule:
+    - cron: "0 7 * * *"  # Run at 7 AM UTC (nightly builds should be done!)
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PRODUCTION_URL: https://sandmark.tarides.com
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r tests/requirements.txt
+          sbase get chromedriver
+      - name: Run tests with pytest
+        run: pytest --data "${PRODUCTION_URL}" -k test_ui

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -35,7 +35,8 @@ def create_test_data():
 
 
 def test_index_page(sb, create_test_data):
-    sb.open("http://localhost:8501")
+    url = "http://localhost:8501" if sb.data is None else sb.data
+    sb.open(url)
     sb.assert_exact_text("Sandmark info", "#sandmark-info")
     sb.assert_exact_text("Latest commit", "#latest-commit")
     for each in app.apps:
@@ -44,7 +45,8 @@ def test_index_page(sb, create_test_data):
 
 
 def test_sequential_benchmarks_page(sb, create_test_data):
-    sb.open("http://localhost:8501")
+    url = "http://localhost:8501" if sb.data is None else sb.data
+    sb.open(url)
     sb.click('label:contains("Sequential Benchmarks")')
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)
@@ -52,7 +54,8 @@ def test_sequential_benchmarks_page(sb, create_test_data):
 
 
 def test_parallel_benchmarks_page(sb, create_test_data):
-    sb.open("http://localhost:8501")
+    url = "http://localhost:8501" if sb.data is None else sb.data
+    sb.open(url)
     sb.click('label:contains("Parallel Benchmarks")')
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)
@@ -60,7 +63,8 @@ def test_parallel_benchmarks_page(sb, create_test_data):
 
 
 def test_perfstat_benchmarks_page(sb, create_test_data):
-    sb.open("http://localhost:8501")
+    url = "http://localhost:8501" if sb.data is None else sb.data
+    sb.open(url)
     sb.click('label:contains("Perfstat Output")')
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -46,9 +46,6 @@ def test_index_page(sb, create_test_data):
 def test_sequential_benchmarks_page(sb, create_test_data):
     sb.open("http://localhost:8501")
     sb.click('label:contains("Sequential Benchmarks")')
-    sb.click(".stSelectbox div")
-    sb.click("li[role=option]:nth-child(2)")
-    time.sleep(2)
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)
     sb.assert_text_not_visible("Traceback:", timeout=1)
@@ -57,9 +54,6 @@ def test_sequential_benchmarks_page(sb, create_test_data):
 def test_parallel_benchmarks_page(sb, create_test_data):
     sb.open("http://localhost:8501")
     sb.click('label:contains("Parallel Benchmarks")')
-    sb.click(".stSelectbox div")
-    sb.click("li[role=option]:nth-child(2)")
-    time.sleep(2)
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)
     sb.assert_text_not_visible("Traceback:", timeout=1)
@@ -68,9 +62,6 @@ def test_parallel_benchmarks_page(sb, create_test_data):
 def test_perfstat_benchmarks_page(sb, create_test_data):
     sb.open("http://localhost:8501")
     sb.click('label:contains("Perfstat Output")')
-    sb.click(".stSelectbox div")
-    sb.click("li[role=option]:nth-child(2)")
-    time.sleep(2)
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)
     sb.assert_text_not_visible("Traceback:", timeout=1)


### PR DESCRIPTION
We've had a bunch of issues recently reported by our users -- for instance #97, #89, #83, etc.  This PR adds a cron job that runs on GitHub actions and checks the UI for exceptions. Failed builds would be notified on GitHub and not on Slack, but this may be a good first step for us to proactively find issues and fix them, instead of discovering issues only when reported by our users.

(Some runs of this action can be found here: https://github.com/punchagan/sandmark-nightly/actions/workflows/production-user-tests.yml)

The PR also has a few improvements to the Python tests and running them via GH actions.