### PR TITLE
Move @here mention to markdown section from header

### DIFF
--- a/.github/workflows/copy-successful-builds.yml
+++ b/.github/workflows/copy-successful-builds.yml
@@ -1,5 +1,6 @@
 # Workflow to copy successful builds to main branch
 ---
+name: Copy Successful builds from testing to main branch
 on:
   # Triggers the workflow on push to testing branch, containing bench files
   push:

--- a/scripts/slack-notify-build-status.sh
+++ b/scripts/slack-notify-build-status.sh
@@ -55,7 +55,7 @@ if [ -n "${FAILED_BUILDS:-}" ]; then
                         \"type\": \"header\",
                         \"text\": {
                                 \"type\": \"plain_text\",
-                                \"text\": \":x: Failed builds on ${HOSTNAME} <!here>\"
+                                \"text\": \":x: Failed builds on ${HOSTNAME}\"
                         }
                 },
                 {
@@ -69,7 +69,7 @@ if [ -n "${FAILED_BUILDS:-}" ]; then
                         \"type\": \"section\",
                         \"text\": {
                                 \"type\": \"mrkdwn\",
-                                \"text\": \"Click here to see the <$(commit_url ${TESTING_COMMIT})|commit> on testing\"
+                                \"text\": \"<!here> Click here to see the <$(commit_url ${TESTING_COMMIT})|commit> on testing\"
                         }
                 }"
 fi


### PR DESCRIPTION
The <!here> syntax doesn't trigger an @here mention when the text is present in the header section. This commit moves it to a markdown section.