### PR TITLE
Fix the versions of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit
-nested_dict
-seaborn
+streamlit==1.14.0
+nested-dict==1.61
+seaborn==0.11.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-pytest
-seleniumbase
+pytest==7.2.0
+seleniumbase==4.8.0


### PR DESCRIPTION
Seaborn got updated to `0.12` automatically and that caused the parallel benchmarks to throw a traceback in the UI for the latest benchmark run where the data for `mergesort` run has NA values. 