### PR TITLE
status: Fix checkout_testing_branch to work on production

### DIFF
--- a/app/pages/status.py
+++ b/app/pages/status.py
@@ -15,10 +15,10 @@ GLOB_PAT = "**/{date:%Y%m%d}_*/**/*.log"
 @st.cache(ttl=300)
 def checkout_testing_branch():
     path = "/tmp/sandmark-nightly-testing-branch"
+    branch = "testing"
     os.makedirs(path, exist_ok=True)
-    subprocess.check_call(
-        ["git", "--work-tree", str(path), "checkout", "testing", "--", "."]
-    )
+    subprocess.check_call(["git", "fetch", "--force", "origin", f"{branch}:{branch}"])
+    subprocess.check_call(["git", "--work-tree", path, "checkout", branch, "--", "."])
     subprocess.check_call(["git", "reset"])
     return path
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -69,3 +69,11 @@ def test_perfstat_benchmarks_page(sb, create_test_data):
     sb.wait_for_text_not_visible("Running...")
     time.sleep(2)
     sb.assert_text_not_visible("Traceback:", timeout=1)
+
+
+def test_status_page(sb, create_test_data):
+    url = "http://localhost:8501" if sb.data is None else sb.data
+    sb.open(f"{url}/status")
+    sb.wait_for_text_not_visible("Running...")
+    time.sleep(2)
+    sb.assert_text_not_visible("Traceback:", timeout=1)


### PR DESCRIPTION
Fetch the testing branch from the origin remote, just to make sure we that the
branch exists when trying to switch to it. It also ensures that we are using
the latest version of the branch each time we check status.