### PR TITLE
Detect make errors when validating benchmark logs

### DIFF
--- a/app/validate_run.py
+++ b/app/validate_run.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import re
 
 
 def bench_file_has_content(path, n=1):
@@ -20,7 +21,7 @@ def log_has_no_errors(path):
     log_file = log_files[0]
     with open(log_file) as f:
         log_text = f.read()
-    return "Error:" not in log_text, log_file
+    return not re.search(r"\bError\b", log_text), log_file
 
 
 def is_valid(path):
@@ -32,8 +33,8 @@ def is_valid(path):
 
 if __name__ == "__main__":
     import argparse
-    from pathlib import Path
     import sys
+    from pathlib import Path
 
     parser = argparse.ArgumentParser()
     parser.add_argument("path", help="Path to a results directory")


### PR DESCRIPTION
Previously, errors like the following would not be detected, which are now detected and the validation of the log file fails.

```
make: *** [Makefile:228: ocaml-versions/5.1.0+stable.bench] Error 1
```