### PR TITLE
Use a fixed version of Pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit==1.14.0
 nested-dict==1.61
 seaborn==0.11.2
+pandas==1.5.3


### PR DESCRIPTION
The parallel benchmarks app is broken app with Pandas 2.0.0

The failure was detected using the daily production UI test [here](https://github.com/ocaml-bench/sandmark-nightly/actions/runs/4604979824/jobs/8136472315) and can also be seen in the Sandmark nightly UI, [here](https://sandmark.tarides.com/?app=Parallel+Benchmarks&parallel_num_variants=1&parallel_01=20230405&parallel_02=turing_5.1.0%2Btrunk%2Bparallel_20230405_8746939&parallel_find_by=variant&parallel_00=5.1.0%2Btrunk%2Bparallel)