### PR TITLE
Don't update the testing branch if it's already checked out

### DIFF
--- a/app/pages/status.py
+++ b/app/pages/status.py
@@ -16,7 +16,9 @@ def checkout_testing_branch():
     path = "/tmp/sandmark-nightly-testing-branch"
     branch = "testing"
     os.makedirs(path, exist_ok=True)
-    subprocess.check_call(["git", "fetch", "--force", "origin", f"{branch}:{branch}"])
+    current_branch = subprocess.check_output(["git", "branch", "--show-current"]).decode().strip()
+    if current_branch != branch:
+        subprocess.check_call(["git", "fetch", "--force", "origin", f"{branch}:{branch}"])
     subprocess.check_call(["git", "--work-tree", path, "checkout", branch, "--", "."])
     subprocess.check_call(["git", "reset"])
     return path


### PR DESCRIPTION
The status page UI test fails on the testing branch, since git doesn't allow fetch and updating a currently checked out branch.  This commit adds a check for the current branch and avoids updating the currently checked out code.