### PR TITLE
Use st.cache_data instead of st.cache

### DIFF
--- a/app/pages/status.py
+++ b/app/pages/status.py
@@ -11,7 +11,7 @@ ROOT = Path(__file__).parent.parent.parent
 GLOB_PAT = "**/{date:%Y%m%d}_*/**/*.log"
 
 
-@st.cache(ttl=300)
+@st.cache_data(ttl=300)
 def checkout_testing_branch():
     path = "/tmp/sandmark-nightly-testing-branch"
     branch = "testing"


### PR DESCRIPTION
With the upgrade to Streamlit 1.22.0 in
deb0163fe7a6f18c96348ff8daa569b905cbd79c, the function st.cache is deprecated.