### PR TITLE
Add link to report issues with the service at ocaml/infrastructure

### DIFF
--- a/app/apps/index.py
+++ b/app/apps/index.py
@@ -127,6 +127,10 @@ def app():
                     1:  22  10
                 ```
     """
+        ### Reporting issues
+        
+        Please report any issues with the Sandmark Nightly Service at [ocaml/infrastructure](https://github.com/ocaml/infrastructure/issues)
+
     )
     st.header("Sandmark info")
     st.subheader("Latest commit")


### PR DESCRIPTION
This PR adds a note on the front page directing to report issues with the service on [ocaml/infrastructure](https://github.com/ocaml/infrastructure/issues).