### PR TITLE
Fix test get commit id failures

### DIFF
--- a/app/apps/index.py
+++ b/app/apps/index.py
@@ -1,5 +1,4 @@
 import pathlib
-import re
 
 import streamlit as st
 
@@ -8,7 +7,7 @@ def get_commit_id(path):
     with open(path, "rb") as file_:
         for line in file_:
             # commit keyword points to the latest commit of sandmark
-            if re.search(b"commit", line):
+            if line.startswith(b"commit"):
                 return line.decode("utf8")
     return "commit unknown"
 

--- a/app/apps/index.py
+++ b/app/apps/index.py
@@ -5,11 +5,11 @@ import streamlit as st
 
 
 def get_commit_id(path):
-    with open(path, "r") as file_:
+    with open(path, "rb") as file_:
         for line in file_:
             # commit keyword points to the latest commit of sandmark
-            if re.search("commit", line):
-                return line
+            if re.search(b"commit", line):
+                return line.decode("utf8")
     return "commit unknown"
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,11 +1,17 @@
+import re
+
 from apps.index import get_commit_id, get_the_latest_commits
 
 from . import ROOT_DIR
 
 
 def test_commit_id():
+    pattern = re.compile("^commit [0-9a-f]{40}$")
     for path in ROOT_DIR.rglob("*.log"):
-        assert get_commit_id(path).startswith("commit ")
+        commit = get_commit_id(path)
+        if commit == "commit unknown":
+            continue
+        assert pattern.match(commit) is not None
 
 
 def test_get_latest_commits():


### PR DESCRIPTION
Due to an opam repository bug, some of our log files contained a non UTF-8 character. Our code to find git commit ID from log files was crashing due to this, which this PR fixes.