### PR TITLE
Upgrade seleniumbase to latest version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,1 @@
-seleniumbase==4.11.8
+seleniumbase==4.21.4


### PR DESCRIPTION
The download process for downloading the latest chromedriver was changed recently, which causes `sbase get chromedriver latest` to install a slightly older version that doesn't work with the latest browser. The newer version of seleniumbase fixes `sbase get` command to fetch the latest driver.

Fixes CI runs like [this](https://github.com/ocaml-bench/sandmark-nightly/actions/runs/6940436726)